### PR TITLE
Allow ability to delete deployment after backup

### DIFF
--- a/roles/pvc/mysql_pvc/defaults/main.yml
+++ b/roles/pvc/mysql_pvc/defaults/main.yml
@@ -7,3 +7,4 @@ with_resources: true
 with_backup: true
 with_restore: true
 with_data: false
+delete_after_backup: false

--- a/roles/pvc/mysql_pvc/tasks/delete.yml
+++ b/roles/pvc/mysql_pvc/tasks/delete.yml
@@ -1,0 +1,20 @@
+- name: Delete resources
+  k8s:
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ item }}"
+  loop: "{{ namespaces_to_delete }}"
+
+- name: Wait 2 minutes for namespace to be deleted
+  k8s_facts:
+    kind: Namespace
+    api_version: v1
+    name: "{{ item }}"
+  register: ns
+  until: not ns.get("resources", [""])
+  retries: 80
+  delay: 3
+  loop: "{{ namespaces_to_delete }}"

--- a/roles/pvc/mysql_pvc/tasks/main.yml
+++ b/roles/pvc/mysql_pvc/tasks/main.yml
@@ -17,30 +17,32 @@
       shell: |
               oc rsync -n mysql-persistent {{ src }} {{ pod_name }}:{{ dest }} --exclude=* --include=*.sql
               oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "mysql -uMYSQL_USER -pMYSQL_PASSWORD MYSQL_DATABASE < data.sql"
-
   when: with_resources
 
 - name: Saving the information about the database for tests
   vars:
     pod_name: "{{ pod.resources[0].get('metadata', {}).get('name', '') }}"
   block:
-  - name: Get the size of the database
-    shell: oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "du -h /var/lib/mysql | awk '/MYSQL_DATABASE/ {print}' | cut -f1"
-    register: database_size
 
-  - name: Get the checksum of the database
-    shell: oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "md5sum /var/lib/mysql/data/MYSQL_DATABASE/t1.ibd | cut -d ' ' -f 1"
-    register: database_checksum
+    - name: Get the size of the database
+      shell: oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "du -h /var/lib/mysql | awk '/MYSQL_DATABASE/ {print}' | cut -f1"
+      register: database_size
 
-  - name: Copy files into testing directory
-    lineinfile:
-      path: "{{ playbook_dir }}/roles/pvc/mysql_pvc_database/files/database_info.txt"
-      line: "{{ item }}"
-      insertafter: EOF
-      create: yes
-    with_items:
-      - "{{ database_size.stdout }}"
-      - "{{ database_checksum.stdout }}"
+    - name: Get the checksum of the database
+      shell: oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "md5sum /var/lib/mysql/data/MYSQL_DATABASE/t1.ibd | cut -d ' ' -f 1"
+      register: database_checksum
+
+    - name: Copy files into testing directory
+      lineinfile:
+        path: "{{ playbook_dir }}/roles/pvc/mysql_pvc_database/files/database_info.txt"
+        line: "{{ item }}"
+        insertafter: EOF
+        create: yes
+      with_items:
+        - "{{ database_size.stdout }}"
+        - "{{ database_checksum.stdout }}"
+
+  when: with_resources
 
 - name: Create a backup
   when: with_backup
@@ -58,3 +60,7 @@
 
     - name: Check if restored and bound
       include: check.yml
+
+- name: Delete resources after backup
+  when: delete_after_backup
+  include_tasks: "delete.yml"


### PR DESCRIPTION
This helps assist use cases where backups and restores are performed on different clusters and there is a need to remove the existing project once it is backed up.

Also, the save DB information block should only run when there is a deployment actually there, not in all cases, like in a restore case where there is nothing deployed yet.