### PR TITLE
Add initial mig-controller based e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 *.swp
+config/mig_controller.yml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,75 @@
 # mig-e2e
-End to end tests for OCP Migration
+End to end tests for OCP 3 to 4 Migration
 
-* Run ```ansible-playbook mysql-pvc.yml``` for deploy, backup or restore the mysql example.
-* Run ```ansible-playbook mysql-pvc-test.yml``` for testing your mysql:
-    * Test of resources
-    * Test of the data in the database
+## Pre-requisites
+
+* OCP3 v3.7 (or higher) and OCP4 clusters, these would be the _source_ and _destination_ clusters used to migrate workloads
+* [mig-controller](https://github.com/fusor/mig-controller) must be deployed on _one of the two_ clusters
+* Velero must be deployed on both clusters and will be driven by mig-controller (see instructions [here](https://github.com/fusor/mig-controller#quick-start))
+* S3 temporary migration storage must be provisioned on AWS for mig-controller to consume
+* NFS or other compatible volume storage must be provisioned on both clusters for PVC based test
+
+## Mig-controller config variables
+
+A number of parameters need to be set with the correct environment in order to create the CRs for migration purposes. A [sample](https://github.com/fusor/mig-e2e/config/mig_controller.yml.example) file is supplied, **please make changes as necessary**.
+
+See below for a decription of these paremeters :
+
+| Parameter | Purpose |
+| --- | --- |
+| `mig_controller_remote_cluster_url` | Endpoint of remote cluster mig-controller will connect to |
+| `mig_controller_aws_access_key` | Base64 encoded AWS access key to auth with AWS services |
+| `mig_controller_aws_secret_key` | Base64 encoded AWS secret access key to auth with AWS services |
+| `mig_controller_sa_token` | Base64 encoded SA token used to authenticate with remote cluster |
+| `mig_controller_aws_bucket_name` | Name of the S3 bucket to be used for temporary Migration storage |
+| `mig_controller_aws_bucket_region` | Region of S3 bucket to be used for temporary Migration storage |
+
+## Other considerations
+
+* You must be _logged in_ to the cluster where mig-controller is running before attempting to run tests
+* By default, the source cluster is assumed to be the host for mig-controller
+
+## Running tests
+
+The following example test will deploy and migrate nginx
+
+```bash
+$ ansible-playbook nginx.yml
+```
+
+The migration will be tracked to completion, you can also check the status of each _phase of the migration_ using : 
+
+```bash
+$ oc -n mig describe migmigration nginx-mig-1560432273
+Name:         nginx-mig-1560432273
+Namespace:    mig
+Labels:       controller-tools.k8s.io=1.0
+Annotations:  touch=ac3a02d7-3249-4d19-9978-53b39cd2f93a
+API Version:  migration.openshift.io/v1alpha1
+Kind:         MigMigration
+Metadata:
+  Creation Timestamp:  2019-06-13T13:24:56Z
+  Generation:          1
+  Resource Version:    16515215
+  Self Link:           /apis/migration.openshift.io/v1alpha1/namespaces/mig/migmigrations/nginx-mig-1560432273
+  UID:                 a2d9e866-8dde-11e9-8678-0e0ae8a21422
+Spec:
+  Mig Plan Ref:
+    Name:       nginx-migplan-1560432273
+    Namespace:  mig
+  Stage:        false
+Status:
+  Completion Timestamp:  2019-06-13T13:28:06Z
+  Conditions:
+    Category:              Critical
+    Last Transition Time:  2019-06-13T13:28:06Z
+    Message:               The referenced `migPlanRef` does not have a `Ready` condition.
+    Status:                True
+    Type:                  PlanNotReady
+  Migration Completed:     true
+  Phase:                   Completed
+  Start Timestamp:         2019-06-13T13:24:57Z
+Events:                    <none>
+```
+
+_**Note:**_ The migration name will be printed during the ansible playbook run

--- a/config/mig_controller.yml.example
+++ b/config/mig_controller.yml.example
@@ -1,0 +1,6 @@
+mig_controller_remote_cluster_url: https://api.ocp4-dev.mg.dog8code.com:6443
+mig_controller_aws_access_key: <Base64 encoded AWS access key>
+mig_controller_aws_secret_key: <Base64 encoded AWS secret key>
+mig_controller_aws_bucket_name: velero-903889c1a2xxxxxxxx
+mig_controller_aws_bucket_region: us-east-1
+mig_controller_sa_token: <Base64 encoded SA token for remote cluster>

--- a/nginx.yml
+++ b/nginx.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  roles:
+    - nginx
+  vars_files:
+    - "{{ playbook_dir }}/config/mig_controller.yml"
+

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 migration_plan_name: nginx-migplan-{{ ansible_date_time.epoch }}
 migration_name: nginx-mig-{{ ansible_date_time.epoch }}
-namespace: nginx-example
 with_deploy: true
 with_migrate: true
+namespaces:
+- nginx-example

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+migration_plan_name: nginx-migplan-{{ ansible_date_time.epoch }}
+migration_name: nginx-mig-{{ ansible_date_time.epoch }}
+namespace: nginx-example
+with_deploy: true
+with_migrate: true

--- a/roles/nginx/files/mig-cluster-local.yml
+++ b/roles/nginx/files/mig-cluster-local.yml
@@ -1,0 +1,11 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migcluster-local
+  namespace: mig
+spec:
+  # [!] Change isHostCluster to 'false' if you want to use a clusterRef and serviceAccountSecretRef
+  #     instead of using the mig-controller detected kubeconfig. Refer to mig-cluster-aws.yaml for an example.
+  isHostCluster: true

--- a/roles/nginx/files/mig-cluster-remote.yml
+++ b/roles/nginx/files/mig-cluster-remote.yml
@@ -1,0 +1,19 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migcluster-remote
+  namespace: mig
+spec:
+  # [!] Change isHostCluster to 'true' if you'll be running the controller on this cluster.
+  #     Setting 'isHostCluster' to true will bypass using the clusterRef and serviceAccountSecretRef below.
+  isHostCluster: false
+
+  clusterRef:
+    name: remote-cluster
+    namespace: mig
+
+  serviceAccountSecretRef:
+    name: sa-token-remote
+    namespace: mig

--- a/roles/nginx/files/nginx.yml
+++ b/roles/nginx/files/nginx.yml
@@ -1,0 +1,74 @@
+# Copyright 2017 the Heptio velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-example
+  labels:
+    app: nginx
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: nginx-example
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: docker.io/twalter/openshift-nginx
+        name: nginx
+        ports:
+        - containerPort: 8081
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: my-nginx
+  namespace: nginx-example
+spec:
+  ports:
+  - port: 8081
+    targetPort: 8081
+  selector:
+    app: nginx
+  type: LoadBalancer
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: my-nginx
+  namespace: nginx-example
+  labels:
+    app: nginx
+    service: my-nginx
+spec:
+  to:
+    kind: Service
+    name: my-nginx
+  port:
+    targetPort: 8081

--- a/roles/nginx/tasks/check.yml
+++ b/roles/nginx/tasks/check.yml
@@ -1,0 +1,9 @@
+- name: Wait for nginx deployment
+  k8s_facts:
+    kind: Pod
+    namespace: nginx-example
+    label_selectors: "app=nginx"
+  register: pod
+  until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 10
+  delay: 15

--- a/roles/nginx/tasks/deploy.yml
+++ b/roles/nginx/tasks/deploy.yml
@@ -1,0 +1,7 @@
+- name: Deploy nginx from yaml
+  k8s:
+    state : present
+    definition: "{{ lookup('file', 'nginx.yml')}}"
+
+- name: Check if deployed 
+  include: check.yml

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate

--- a/roles/nginx/tasks/migrate.yml
+++ b/roles/nginx/tasks/migrate.yml
@@ -1,0 +1,46 @@
+# Source migration cluster does not need credentials isHostCluster: true
+- name: Create source cluster migration definition
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'mig-cluster-local.yml')}}"
+
+- name: Create remote cluster definition
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'cluster-remote.yml.j2') }}"
+
+- name: Create SA token on destination cluster
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'sa-secret-remote.yml.j2') }}"
+
+- name: Create remote cluster migration defition
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'mig-cluster-remote.yml') }}"
+
+- name: Create migration storage creds
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'mig-storage-creds.yml.j2') }}"
+
+- name: Create migration storage
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'mig-storage.yml.j2') }}"
+
+- name: Create migration plan
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'mig-plan.yml.j2') }}"
+
+- debug:
+    msg: "Created migration plan : {{ migration_plan_name }}"
+
+- name: Execute migration
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'mig-migration.yml.j2') }}"
+
+- debug:
+    msg: "Created migration name : {{ migration_name }}"

--- a/roles/nginx/tasks/migrate.yml
+++ b/roles/nginx/tasks/migrate.yml
@@ -37,6 +37,11 @@
 - debug:
     msg: "Created migration plan : {{ migration_plan_name }}"
 
+# Fix me: https://github.com/fusor/mig-controller/issues/84
+- name: Allow velero to reconcile changes before attempting migration
+  pause:
+    seconds: 60
+
 - name: Execute migration
   k8s:
     state: present

--- a/roles/nginx/tasks/track.yml
+++ b/roles/nginx/tasks/track.yml
@@ -1,0 +1,33 @@
+---
+- name: Check if backup phase started
+  k8s_facts:
+    kind: MigMigration
+    api_version: v1alpha1
+    namespace: mig
+    name: "{{ migration_name }}" 
+  register: backup
+  until: backup.resources[0].status.phase == "BackupStarted"
+  retries: 60
+  delay: 5
+
+- name: Check if restore phase started
+  k8s_facts:
+    kind: MigMigration
+    api_version: v1alpha1
+    namespace: mig
+    name: "{{ migration_name }}"
+  register: restore
+  until: restore.resources[0].status.phase == "RestoreStarted"
+  retries: 60
+  delay: 5
+
+- name: Check if migration completed
+  k8s_facts:
+    kind: MigMigration
+    api_version: v1alpha1
+    namespace: mig
+    name: "{{ migration_name }}"
+  register: migration
+  until: migration.resources[0].status.phase == "Completed"
+  retries: 60
+  delay: 5

--- a/roles/nginx/tasks/track.yml
+++ b/roles/nginx/tasks/track.yml
@@ -6,7 +6,7 @@
     namespace: mig
     name: "{{ migration_name }}" 
   register: backup
-  until: backup.resources[0].status.phase == "BackupStarted"
+  until: backup.resources[0].get("status", {}).get("phase", "") == "BackupStarted"
   retries: 60
   delay: 5
 
@@ -17,7 +17,8 @@
     namespace: mig
     name: "{{ migration_name }}"
   register: restore
-  until: restore.resources[0].status.phase == "RestoreStarted"
+#  until: restore.resources[0].status.phase == "RestoreStarted"
+  until: restore.resources[0].get("status", {}).get("phase", "") == "RestoreStarted"
   retries: 60
   delay: 5
 
@@ -28,6 +29,7 @@
     namespace: mig
     name: "{{ migration_name }}"
   register: migration
-  until: migration.resources[0].status.phase == "Completed"
+#  until: migration.resources[0].status.phase == "Completed"
+  until: migration.resources[0].get("status", {}).get("phase", "") == "Completed"
   retries: 60
   delay: 5

--- a/roles/nginx/templates/cluster-remote.yml.j2
+++ b/roles/nginx/templates/cluster-remote.yml.j2
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  namespace: mig
+  name: remote-cluster
+spec:
+  kubernetesApiEndpoints:
+    serverEndpoints:
+      - clientCIDR: "0.0.0.0"
+        # [!] Change serverAddress to point at your remote cluster login endpoint
+        serverAddress: {{ mig_controller_remote_cluster_url }}

--- a/roles/nginx/templates/mig-migration.yml.j2
+++ b/roles/nginx/templates/mig-migration.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigMigration
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{ migration_name }}
+  namespace: mig
+spec:
+  stage: false
+  migPlanRef:
+    name: {{ migration_plan_name }}
+    namespace: mig
+

--- a/roles/nginx/templates/mig-plan.yml.j2
+++ b/roles/nginx/templates/mig-plan.yml.j2
@@ -1,0 +1,24 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigPlan
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{ migration_plan_name }}
+  namespace: mig
+spec:
+
+  srcMigClusterRef:
+    name: migcluster-local
+    namespace: mig
+
+  destMigClusterRef:
+    name: migcluster-remote
+    namespace: mig
+
+  migStorageRef:
+    name: migstorage-sample
+    namespace: mig
+
+  # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster
+  namespaces:
+  - {{ namespace }}

--- a/roles/nginx/templates/mig-plan.yml.j2
+++ b/roles/nginx/templates/mig-plan.yml.j2
@@ -20,5 +20,4 @@ spec:
     namespace: mig
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster
-  namespaces:
-  - {{ namespace }}
+  namespaces: {{ namespaces | to_yaml }}

--- a/roles/nginx/templates/mig-storage-creds.yml.j2
+++ b/roles/nginx/templates/mig-storage-creds.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: mig
+  name: migstorage-creds
+type: Opaque
+data:
+  # [!] If using S3 / AWS, change aws-access-key-id and aws-secret-access-key to contain the base64 encoded keys
+  #     needed to authenticate with the storage specified in migstorage.
+  # [Note] these credentials will be injected into cloud-credentials in the 'velero' namespace.
+  aws-access-key-id: {{ mig_controller_aws_access_key }}
+  aws-secret-access-key: {{ mig_controller_aws_secret_key }}

--- a/roles/nginx/templates/mig-storage.yml.j2
+++ b/roles/nginx/templates/mig-storage.yml.j2
@@ -1,0 +1,32 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigStorage
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migstorage-sample
+  namespace: mig
+spec:
+  backupStorageProvider: aws
+  volumeSnapshotProvider: aws
+  
+  backupStorageConfig:
+    # [!] Change awsBucketName to contain the S3 bucket name to be used for migration
+    awsBucketName: {{ mig_controller_aws_bucket_name }}
+    # [!] Change awsRegion to contain the region name (e.g. 'us-east-1') where the S3 bucket presides
+    awsRegion: {{ mig_controller_aws_bucket_region }}
+    credsSecretRef:
+      namespace: mig
+      name: migstorage-creds
+
+    # Optional backupStorageConfig parameters
+    #awsKmsKeyId: foo
+    #awsPublicUrl: foo
+    #awsSignatureVersion: "4"
+
+  volumeSnapshotConfig:
+    # [!] Change awsRegion to contain the region name (e.g. 'us-east-1') where Volume Snapshots should take place
+    awsRegion: {{ mig_controller_aws_bucket_region }}
+    credsSecretRef:
+      namespace: mig
+      name: migstorage-creds
+

--- a/roles/nginx/templates/sa-secret-remote.yml.j2
+++ b/roles/nginx/templates/sa-secret-remote.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sa-token-remote
+  namespace: mig
+type: Opaque
+data:
+  # [!] Change saToken to contain a base64 encoded SA token with cluster-admin privileges on the remote (AWS) cluster
+  saToken: {{ mig_controller_sa_token }}


### PR DESCRIPTION
- Initial sample e2e test CI job using mig-controller and nginx as a sample scenario
- All CRs templated and using parameters dumped by mig-ci mig_controller_deployment role at config/mig_controller.yml
- Migrations are created with unique migplan and migmigration names (avoids issues with existing objects)
- Migrations are tracked to completion via migmigration phases
- By default we assume the source cluster to host mig-controller
- Documented usage
