### PR TITLE
migration_run velero pause should only run once

### DIFF
--- a/roles/migration_run/tasks/main.yml
+++ b/roles/migration_run/tasks/main.yml
@@ -18,6 +18,10 @@
 - name: Allow velero to reconcile changes before attempting migration
   pause:
     seconds: "{{ mig_velero_timeout }}"
+  when: mig_velero_pause is not defined
+
+- set_fact:
+    mig_velero_pause: true
 
 - name: Execute migration
   k8s:


### PR DESCRIPTION
- Only one pause is necessary to workaround https://github.com/fusor/mig-controller/issues/84