### PR TITLE
Migration_cleanup: Remove residual migplans/migrations

### DIFF
--- a/roles/migration_cleanup/tasks/main.yml
+++ b/roles/migration_cleanup/tasks/main.yml
@@ -1,7 +1,10 @@
-- name: Ensure namespace {{ namespace }} is absent before continuing...
-  k8s:
-    name: "{{ namespace }}"
-    api_version: v1
-    kind: Namespace
-    state: absent
-    wait: yes
+- name: Remove existing namespace
+  import_tasks: remove_namespace.yml
+
+- name: Remove existing migrations
+  import_tasks: remove_migration.yml
+  when: with_migrate|bool
+
+- name: Remove existing migplans
+  import_tasks: remove_migplan.yml
+  when: with_migrate|bool

--- a/roles/migration_cleanup/tasks/remove_migplan.yml
+++ b/roles/migration_cleanup/tasks/remove_migplan.yml
@@ -1,0 +1,30 @@
+# k8s field_selectors cannot be used for CRs, API only supports core resources
+- name: Check existing migplans for {{ migration_sample_name }}
+  k8s_facts:
+    api_version: v1alpha1
+    kind: MigPlan
+    namespace: mig
+  register: all_migplans
+
+- block:
+
+  - name: Extract discovered migplans for {{ migration_sample_name }}
+    set_fact:
+      migplans_to_remove: "{{ all_migplans | json_query('resources[].metadata.name') | select('match', migration_sample_name) | list }}"
+
+  - debug:
+      msg: 
+        - "These existing migplans will be removed :"
+        - "{{ migplans_to_remove }}"
+
+  - name: Remove existing migplans for {{ migration_sample_name }}
+    k8s:
+      state: absent
+      api_version: v1alpha1
+      kind: MigPlan
+      namespace: mig
+      name: "{{ item }}"
+      wait: yes
+    loop: "{{ migplans_to_remove }}"
+
+  when: "migration_sample_name in (all_migplans | json_query('resources[].metadata.name') | string )"

--- a/roles/migration_cleanup/tasks/remove_migration.yml
+++ b/roles/migration_cleanup/tasks/remove_migration.yml
@@ -1,0 +1,30 @@
+# k8s field_selectors cannot be used for CRs, API only supports core resources
+- name: Check existing migrations for {{ migration_sample_name }}
+  k8s_facts:
+    api_version: v1alpha1
+    kind: MigMigration
+    namespace: mig
+  register: all_migrations
+
+- block:
+
+  - name: Extract discovered migrations for {{ migration_sample_name }}
+    set_fact:
+      migrations_to_remove: "{{ all_migrations | json_query('resources[].metadata.name') | select('match', migration_sample_name) | list }}"
+
+  - debug:
+      msg: 
+        - "These existing migrations will be removed :"
+        - "{{ migrations_to_remove }}"
+
+  - name: Remove existing migrations for {{ migration_sample_name }}
+    k8s:
+      state: absent
+      api_version: v1alpha1
+      kind: MigMigration
+      namespace: mig
+      name: "{{ item }}"
+      wait: yes
+    loop: "{{ migrations_to_remove }}"
+
+  when: "migration_sample_name in (all_migrations | json_query('resources[].metadata.name') | string )"

--- a/roles/migration_cleanup/tasks/remove_namespace.yml
+++ b/roles/migration_cleanup/tasks/remove_namespace.yml
@@ -1,0 +1,7 @@
+- name: Ensure namespace {{ namespace }} is absent before continuing...
+  k8s:
+    name: "{{ namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: absent
+    wait: yes


### PR DESCRIPTION
This PR does two things : 
* Removes any residual migrations matching only the role calling (i.e nfs-pv, stateless)
* Removes any residual migplans matching only the role calling

These changes only affect **migration mode** , they do not have any effect on deployment mode.

This helps avoiding mig-controller conflicts when re-running migrations over the same project/test, also it will assist roles that could potentially run the same migration twice with different parameters.

Only the last remaining migration for an e2e test role will be kept, any older ones will be removed.