### PR TITLE
Add default migration namespace

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,0 +1,3 @@
+# default common variables for mig-e2e roles/plays
+
+migration_namespace: mig

--- a/mig_controller_samples.yml
+++ b/mig_controller_samples.yml
@@ -6,3 +6,4 @@
     - { role: nfs-pv, tags: ["nfs-pv"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
+    - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/migration_cleanup/tasks/remove_migplan.yml
+++ b/roles/migration_cleanup/tasks/remove_migplan.yml
@@ -3,7 +3,7 @@
   k8s_facts:
     api_version: v1alpha1
     kind: MigPlan
-    namespace: mig
+    namespace: "{{ migration_namespace }}"
   register: all_migplans
 
 - block:
@@ -22,7 +22,7 @@
       state: absent
       api_version: v1alpha1
       kind: MigPlan
-      namespace: mig
+      namespace: "{{ migration_namespace }}"
       name: "{{ item }}"
       wait: yes
     loop: "{{ migplans_to_remove }}"

--- a/roles/migration_cleanup/tasks/remove_migration.yml
+++ b/roles/migration_cleanup/tasks/remove_migration.yml
@@ -3,7 +3,7 @@
   k8s_facts:
     api_version: v1alpha1
     kind: MigMigration
-    namespace: mig
+    namespace: "{{ migration_namespace }}"
   register: all_migrations
 
 - block:
@@ -22,7 +22,7 @@
       state: absent
       api_version: v1alpha1
       kind: MigMigration
-      namespace: mig
+      namespace: "{{ migration_namespace }}"
       name: "{{ item }}"
       wait: yes
     loop: "{{ migrations_to_remove }}"

--- a/roles/migration_prepare/tasks/prepare_clusters.yml
+++ b/roles/migration_prepare/tasks/prepare_clusters.yml
@@ -6,7 +6,7 @@
 - name: Create source cluster migration definition
   k8s:
     state: present
-    definition: "{{ lookup('file', 'mig-cluster-local.yml')}}"
+    definition: "{{ lookup('template', 'mig-cluster-local.yml.j2')}}"
 
 - name: Create remote cluster definition
   k8s:
@@ -21,7 +21,7 @@
 - name: Create remote cluster migration defition
   k8s:
     state: present
-    definition: "{{ lookup('file', 'mig-cluster-remote.yml') }}"
+    definition: "{{ lookup('template', 'mig-cluster-remote.yml.j2') }}"
 
 - name: Create migration storage creds
   k8s:

--- a/roles/migration_prepare/templates/cluster-remote.yml.j2
+++ b/roles/migration_prepare/templates/cluster-remote.yml.j2
@@ -1,7 +1,7 @@
 kind: Cluster
 apiVersion: clusterregistry.k8s.io/v1alpha1
 metadata:
-  namespace: mig
+  namespace: {{ migration_namespace }}
   name: remote-cluster
 spec:
   kubernetesApiEndpoints:

--- a/roles/migration_prepare/templates/mig-cluster-local.yml.j2
+++ b/roles/migration_prepare/templates/mig-cluster-local.yml.j2
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: migcluster-local
-  namespace: mig
+  namespace: {{ migration_namespace }}
 spec:
   # [!] Change isHostCluster to 'false' if you want to use a clusterRef and serviceAccountSecretRef
   #     instead of using the mig-controller detected kubeconfig. Refer to mig-cluster-aws.yaml for an example.

--- a/roles/migration_prepare/templates/mig-cluster-remote.yml.j2
+++ b/roles/migration_prepare/templates/mig-cluster-remote.yml.j2
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: migcluster-remote
-  namespace: mig
+  namespace: {{ migration_namespace }}
 spec:
   # [!] Change isHostCluster to 'true' if you'll be running the controller on this cluster.
   #     Setting 'isHostCluster' to true will bypass using the clusterRef and serviceAccountSecretRef below.
@@ -12,8 +12,8 @@ spec:
 
   clusterRef:
     name: remote-cluster
-    namespace: mig
+    namespace: "{{ migration_namespace }}"
 
   serviceAccountSecretRef:
     name: sa-token-remote
-    namespace: mig
+    namespace: "{{ migration_namespace }}"

--- a/roles/migration_prepare/templates/mig-storage-creds.yml.j2
+++ b/roles/migration_prepare/templates/mig-storage-creds.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: mig
+  namespace: {{ migration_namespace }}
   name: migstorage-creds
 type: Opaque
 data:

--- a/roles/migration_prepare/templates/mig-storage.yml.j2
+++ b/roles/migration_prepare/templates/mig-storage.yml.j2
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: migstorage-sample
-  namespace: mig
+  namespace: {{ migration_namespace }}
 spec:
   backupStorageProvider: aws
   volumeSnapshotProvider: aws
@@ -15,7 +15,7 @@ spec:
     # [!] Change awsRegion to contain the region name (e.g. 'us-east-1') where the S3 bucket presides
     awsRegion: {{ mig_controller_aws_bucket_region }}
     credsSecretRef:
-      namespace: mig
+      namespace: {{ migration_namespace }}
       name: migstorage-creds
 
     # Optional backupStorageConfig parameters
@@ -27,6 +27,6 @@ spec:
     # [!] Change awsRegion to contain the region name (e.g. 'us-east-1') where Volume Snapshots should take place
     awsRegion: {{ mig_controller_aws_bucket_region }}
     credsSecretRef:
-      namespace: mig
+      namespace: {{ migration_namespace }}
       name: migstorage-creds
 

--- a/roles/migration_prepare/templates/sa-secret-remote.yml.j2
+++ b/roles/migration_prepare/templates/sa-secret-remote.yml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: sa-token-remote
-  namespace: mig
+  namespace: {{ migration_namespace }}
 type: Opaque
 data:
   # [!] Change saToken to contain a base64 encoded SA token with cluster-admin privileges on the remote (AWS) cluster

--- a/roles/migration_run/tasks/process_pvs.yml
+++ b/roles/migration_run/tasks/process_pvs.yml
@@ -3,7 +3,7 @@
   k8s_facts:
     kind: MigPlan
     api_version: v1alpha1
-    namespace: mig
+    namespace: "{{ migration_namespace }}"
     name: "{{ migration_plan_name }}"
   register: mig_plan
   until: mig_plan.resources[0].get("spec", {}).get("persistentVolumes", {})

--- a/roles/migration_run/templates/mig-migration.yml.j2
+++ b/roles/migration_run/templates/mig-migration.yml.j2
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: {{ migration_name }}
-  namespace: mig
+  namespace: {{ migration_namespace }}
 spec:
   stage: false
 {% if quiesce is sameas true and quiesce is defined %}
@@ -12,5 +12,5 @@ spec:
 {% endif %}
   migPlanRef:
     name: {{ migration_plan_name }}
-    namespace: mig
+    namespace: {{ migration_namespace }}
 

--- a/roles/migration_run/templates/mig-plan-pv.yml.j2
+++ b/roles/migration_run/templates/mig-plan-pv.yml.j2
@@ -4,20 +4,20 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: {{ migration_plan_name }}
-  namespace: mig
+  namespace: {{ migration_namespace }}
 spec:
 
   srcMigClusterRef:
     name: migcluster-remote
-    namespace: mig
+    namespace: {{ migration_namespace }}
 
   destMigClusterRef:
     name: migcluster-local
-    namespace: mig
+    namespace: {{ migration_namespace }}
 
   migStorageRef:
     name: migstorage-sample
-    namespace: mig
+    namespace: {{ migration_namespace }}
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster
   namespaces: 

--- a/roles/migration_run/templates/mig-plan.yml.j2
+++ b/roles/migration_run/templates/mig-plan.yml.j2
@@ -4,20 +4,20 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: {{ migration_plan_name }}
-  namespace: mig
+  namespace: {{ migration_namespace }}
 spec:
 
   srcMigClusterRef:
     name: migcluster-remote
-    namespace: mig
+    namespace: {{ migration_namespace }}
 
   destMigClusterRef:
     name: migcluster-local
-    namespace: mig
+    namespace: {{ migration_namespace }}
 
   migStorageRef:
     name: migstorage-sample
-    namespace: mig
+    namespace: {{ migration_namespace }}
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster
   namespaces: 

--- a/roles/migration_track/tasks/main.yml
+++ b/roles/migration_track/tasks/main.yml
@@ -3,7 +3,7 @@
   k8s_facts:
     kind: MigMigration
     api_version: v1alpha1
-    namespace: mig
+    namespace: "{{ migration_namespace }}"
     name: "{{ migration_name }}"
   register: mig_phase
   until: mig_phase.resources[0].get("status", {}).get("phase", "") in item

--- a/roles/stateless/tasks/validate.yml
+++ b/roles/stateless/tasks/validate.yml
@@ -11,7 +11,7 @@
 - name: Obtain nginx route
   k8s_facts:
     kind: Route
-    namespace: nginx-example
+    namespace: "{{ namespace }}"
     label_selectors: "app=nginx"
   register: nginx_route
 


### PR DESCRIPTION
In preparation for the mig-controller CR and mig-operator namespace split, implement a default migration_namespace variable for all roles. By default now set "mig" but should be updated once the dependent PRs for the split are merged.

Added a new config/defaults.yml var file to imported by all playbooks, since this affects almost all roles in the repo.

References : 
https://github.com/fusor/mig-operator/pull/30
https://github.com/fusor/mig-controller/issues/220

