### PR TITLE
Add copy method when copy action is requested

### DIFF
--- a/roles/migration_run/templates/mig-plan-pv.yml.j2
+++ b/roles/migration_run/templates/mig-plan-pv.yml.j2
@@ -30,6 +30,9 @@ spec:
     selection:
       action: {{ pv_action }}
       storageClass: {{ storage_class }}
+{% if pv_action == 'copy' %}
+      copyMethod: {{ pv_copy_method }}
+{% endif %}
     supported:
       actions:
       - copy

--- a/roles/nfs-pv/defaults/main.yml
+++ b/roles/nfs-pv/defaults/main.yml
@@ -5,6 +5,7 @@ migration_name: "{{ migration_sample_name}}-mig-{{ ansible_date_time.epoch }}"
 migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
 pv: true
 pv_action: move
+pv_copy_method: filesystem
 quiesce: true
 storage_class: gp2
 oc_binary: "oc"

--- a/roles/parks-app/defaults/main.yml
+++ b/roles/parks-app/defaults/main.yml
@@ -5,6 +5,7 @@ migration_name: "{{ migration_sample_name}}-mig-{{ ansible_date_time.epoch }}"
 migration_sample_files: "{{ playbook_dir }}/mig-demo-apps/apps/{{ migration_sample_name }}"
 pv: true
 pv_action: move
+pv_copy_method: filesystem
 quiesce: true
 storage_class: gp2
 oc_binary: "oc"

--- a/roles/robot-shop/defaults/main.yml
+++ b/roles/robot-shop/defaults/main.yml
@@ -5,6 +5,7 @@ migration_name: "{{ migration_sample_name}}-mig-{{ ansible_date_time.epoch }}"
 migration_sample_files: "{{ playbook_dir }}/mig-demo-apps/apps/{{ migration_sample_name }}"
 pv: true
 pv_action: move
+pv_copy_method: filesystem
 quiesce: true
 storage_class: gp2
 oc_binary: "oc"

--- a/roles/sock-shop/defaults/main.yml
+++ b/roles/sock-shop/defaults/main.yml
@@ -5,6 +5,7 @@ migration_name: "{{ migration_sample_name}}-mig-{{ ansible_date_time.epoch }}"
 migration_sample_files: "{{ playbook_dir }}/mig-demo-apps/apps/{{ migration_sample_name }}"
 pv: true
 pv_action: move
+pv_copy_method: filesystem
 quiesce: true
 storage_class: gp2
 oc_binary: "oc"


### PR DESCRIPTION
- Copy action now supports filesystem and snapshot, allow copy method to
  be set on pv enabled e2e tests
- By default copy_method set to filesystem