### PR TITLE
Use dedicated variable for stage jobs and other fixes

### DIFF
--- a/roles/mediawiki/templates/mariadb.yml
+++ b/roles/mediawiki/templates/mariadb.yml
@@ -15,7 +15,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig

--- a/roles/migration_run/tasks/stage.yml
+++ b/roles/migration_run/tasks/stage.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    migration_name: "{{ migration_name + '-stage-phase' }}"
+    migration_name_stage: "{{ migration_name + '-stage-phase' }}"
 
 - name: Execute stage migration
   k8s:
@@ -9,10 +9,8 @@
     definition: "{{ lookup('template', 'mig-migration-stage.yml.j2') }}"
 
 - debug:
-    msg: "Created stage migration name : {{ migration_name }}"
+    msg: "Created stage migration name : {{ migration_name_stage }}"
 
 - include_role:
     name: migration_track
-
-- set_fact:
-    migration_name: "{{ migration_name.split('-stage-phase')[0] }}"
+    tasks_from: track_stage.yml

--- a/roles/migration_run/templates/mig-migration-stage.yml.j2
+++ b/roles/migration_run/templates/mig-migration-stage.yml.j2
@@ -3,7 +3,7 @@ kind: MigMigration
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: {{ migration_name }}
+  name: {{ migration_name_stage }}
   namespace: {{ migration_namespace }}
 spec:
   stage: true

--- a/roles/migration_track/tasks/track_stage.yml
+++ b/roles/migration_track/tasks/track_stage.yml
@@ -1,10 +1,9 @@
----
-- name: "Check if migration {{ migration_name }} is completed"
+- name: "Check if migration {{ migration_name_stage }} is completed"
   k8s_facts:
     kind: MigMigration
     api_version: v1alpha1
     namespace: "{{ migration_namespace }}"
-    name: "{{ migration_name }}"
+    name: "{{ migration_name_stage }}"
   register: mig_phase
   until: mig_phase.resources[0].get("status", {}).get("phase", "") in 'Completed'
   retries: 60


### PR DESCRIPTION
- Avoid variable precedence issues when redefining role default vars,
  such as migration_name on playbooks calling multiple roles
- Track completion stage only on migration_track
- Ensure mediawiki mariadb PVC requests a correct size PV