### PR TITLE
Enhance storage class handling on e2e tests

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,3 +1,4 @@
 # default common variables for mig-e2e roles/plays
 
 migration_namespace: openshift-migration
+oc_binary: "oc"

--- a/e2e_mig_samples.yml
+++ b/e2e_mig_samples.yml
@@ -4,7 +4,7 @@
     - { role: mssql-app, tags: ["mssql-app"], pv_action: 'copy', stage: 'true' }
     - { role: sock-shop, tags: ["sock-shop"] }
     - { role: robot-shop, tags: ["robot-shop"] }
-    - { role: parks-app, tags: ["parks-app"], pv_action: 'copy' }
+    - { role: parks-app, tags: ["parks-app"], pv_action: 'copy', src_storage_class: 'glusterfs-storage' }
     - { role: mediawiki, tags: ["mediawiki"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"

--- a/roles/local-images/defaults/main.yml
+++ b/roles/local-images/defaults/main.yml
@@ -4,7 +4,6 @@ migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.e
 migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
 migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
 s2i_app_location: "https://github.com/openshift/nodejs-ex"
-oc_binary: "oc"
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/mediawiki/defaults/main.yml
+++ b/roles/mediawiki/defaults/main.yml
@@ -8,8 +8,8 @@ pv_action: move
 pv_copy_method: filesystem
 quiesce: true
 stage: false
-storage_class: gp2
-oc_binary: "oc"
+src_storage_class: ""
+dst_storage_class: gp2
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/mediawiki/templates/mariadb.yml
+++ b/roles/mediawiki/templates/mariadb.yml
@@ -13,6 +13,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
   resources:
     requests:
       storage: 10Gi

--- a/roles/mediawiki/templates/mediawiki.yml
+++ b/roles/mediawiki/templates/mediawiki.yml
@@ -54,6 +54,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
   resources:
     requests:
       storage: 10Gi

--- a/roles/migration_run/templates/mig-plan-pv.yml.j2
+++ b/roles/migration_run/templates/mig-plan-pv.yml.j2
@@ -29,7 +29,7 @@ spec:
   - name: {{ item }}
     selection:
       action: {{ pv_action }}
-      storageClass: {{ storage_class }}
+      storageClass: {{ dst_storage_class }}
 {% if pv_action == 'copy' %}
       copyMethod: {{ pv_copy_method }}
 {% endif %}

--- a/roles/mssql-app/defaults/main.yml
+++ b/roles/mssql-app/defaults/main.yml
@@ -8,8 +8,8 @@ pv_action: move
 pv_copy_method: filesystem
 quiesce: true
 stage: false
-storage_class: gp2
-oc_binary: "oc"
+src_storage_class: ""
+dst_storage_class: gp2
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/mssql-app/tasks/deploy.yml
+++ b/roles/mssql-app/tasks/deploy.yml
@@ -6,4 +6,4 @@
 - name: Deploy {{ migration_sample_name }} sample
   k8s:
     state : present
-    definition: "{{ lookup('file', '{{ migration_sample_files }}/manifest.yaml' )}}"
+    definition: "{{ lookup('template', 'manifest.yml' )}}"

--- a/roles/mssql-app/templates/manifest.yml
+++ b/roles/mssql-app/templates/manifest.yml
@@ -1,0 +1,186 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: mssql-example
+  labels:
+    app: mssql
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secret
+  namespace: mssql-example
+  labels:
+    app: mssql
+stringData:
+  mssql-password: P@ssw0rd1!
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mssql-example-sa
+  namespace: mssql-example
+  labels:
+    component: mssql-example
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mssql-pvc
+  namespace: mssql-example
+  labels:
+    app: mssql
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: mssql-example-scc
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- '*'
+users:
+- system:admin
+- system:serviceaccount:mssql-example:mssql-example-sa
+
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: mssql-deployment
+  namespace: mssql-example
+  labels:
+    app: mssql
+spec:
+  replicas: 1
+  selector:
+    name: mssql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: mssql
+        app: mssql
+    spec:
+      serviceAccountName: mssql-example-sa
+      containers:
+      - env:
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: SA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: mssql-password
+              name: mssql-secret
+        image: quay.io/ocpmigrate/mssql-server:latest
+        imagePullPolicy: Always
+        name: mssql
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 1433
+        resources:
+          limits:
+            memory: "3Gi"
+            cpu: "2"
+          requests:
+            memory: "3Gi"
+            cpu: "2"
+        volumeMounts:
+        - mountPath: "/var/opt/mssql/data"
+          name: mssql-vol
+      volumes:
+      - name: mssql-vol
+        persistentVolumeClaim:
+          claimName: mssql-pvc
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+ name: mssql-service
+ namespace: mssql-example
+spec:
+ selector:
+   app: mssql
+ ports:
+   - protocol: TCP
+     nodePort: 32001
+     port: 1433
+     targetPort: 1433
+ type: LoadBalancer
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+ name: mssql-app-deployment
+ namespace: mssql-example
+spec:
+ replicas: 1
+ template:
+   metadata:
+     labels:
+       app: mssql-app
+   spec:
+     terminationGracePeriodSeconds: 10
+     serviceAccountName: mssql-example-sa
+     containers:
+     - name: mssql-app
+       image: quay.io/ocpmigrate/mssql-sample-app:microsoft
+       imagePullPolicy: Always
+       ports:
+       - containerPort: 5000
+       securityContext:
+         privileged: true
+       env:
+       - name: ConnString
+         value: "Server=mssql-service.mssql-example.svc.cluster.local;Database=ProductCatalog;User ID=WebLogin; password=SQLPass1234!"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+ name: mssql-app-service
+ namespace: mssql-example
+spec:
+ selector:
+   app: mssql-app
+ ports:
+   - name: "tcp"
+     protocol: TCP
+     port: 5000
+     targetPort: 5000
+
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: mssql-app-route
+  namespace: mssql-example
+spec:
+  path: "/"
+  to:
+    kind: Service
+    name: mssql-app-service

--- a/roles/nfs-pv/defaults/main.yml
+++ b/roles/nfs-pv/defaults/main.yml
@@ -8,8 +8,8 @@ pv_action: move
 pv_copy_method: filesystem
 quiesce: true
 stage: false
-storage_class: gp2
-oc_binary: "oc"
+src_storage_class: ""
+dst_storage_class: gp2
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/nfs-pv/tasks/check.yml
+++ b/roles/nfs-pv/tasks/check.yml
@@ -5,8 +5,8 @@
     label_selectors: "app=mysql"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
-  retries: 10
-  delay: 15
+  retries: 30
+  delay: 10
 
 - name: Check if volume is bound
   k8s_facts:

--- a/roles/nfs-pv/tasks/deploy.yml
+++ b/roles/nfs-pv/tasks/deploy.yml
@@ -6,7 +6,7 @@
 - name: Deploy mysql sample
   k8s:
     state : present
-    definition: "{{ lookup('file', '{{ migration_sample_files }}/mysql-persistent-template.yml' )}}"
+    definition: "{{ lookup('template', 'mysql-persistent-template.yml' )}}"
 
 - name: Check if deployed 
   include: check.yml

--- a/roles/nfs-pv/tasks/validate.yml
+++ b/roles/nfs-pv/tasks/validate.yml
@@ -5,5 +5,5 @@
     label_selectors: "app=mysql"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
-  retries: 10
-  delay: 15
+  retries: 30
+  delay: 10

--- a/roles/nfs-pv/templates/mysql-persistent-template.yml
+++ b/roles/nfs-pv/templates/mysql-persistent-template.yml
@@ -45,7 +45,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  storageClassName: ""
+  storageClassName: {{ src_storage_class | quote }}
   resources:
     requests:
       storage: 10Gi

--- a/roles/parks-app/defaults/main.yml
+++ b/roles/parks-app/defaults/main.yml
@@ -8,8 +8,8 @@ pv_action: move
 pv_copy_method: filesystem
 quiesce: false
 stage: false
-storage_class: gp2
-oc_binary: "oc"
+src_storage_class: ""
+dst_storage_class: gp2
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/parks-app/tasks/deploy.yml
+++ b/roles/parks-app/tasks/deploy.yml
@@ -6,7 +6,7 @@
 - name: Deploy {{ migration_sample_name }} sample
   k8s:
     state : present
-    definition: "{{ lookup('file', '{{ migration_sample_files }}/manifest.yaml' )}}"
+    definition: "{{ lookup('template', 'manifest.yml' )}}"
 
 - name: Check s2i build {{ migration_sample_name }} restify is completed
   k8s_facts:

--- a/roles/parks-app/templates/manifest.yml
+++ b/roles/parks-app/templates/manifest.yml
@@ -1,0 +1,238 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: parks-app
+
+---
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: restify
+  namespace: parks-app
+  labels:
+    app: restify
+spec: {}
+status:
+  dockerImageRepository: ''
+
+---
+kind: BuildConfig
+apiVersion: v1
+metadata:
+  name: restify
+  namespace: parks-app
+  labels:
+    app: restify
+spec:
+  triggers:
+  - type: GitHub
+    github:
+      secret: 4Xwu0tyAab90aaoasd88qweAasdaqvjknfrl3qwpo
+  - type: Generic
+    generic:
+      secret: 4Xwu0tyAab90aaoasd88qweAasdaqvjknfrl3qwpo
+  - type: ConfigChange
+  - type: ImageChange
+    imageChange: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/ryanj/restify-mongodb-parks
+      ref: master
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        namespace: openshift
+        name: nodejs:0.10
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "restify:latest"
+  resources: {}
+status:
+  lastVersion: 0
+
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: restify
+  namespace: parks-app
+  labels:
+    app: restify
+spec:
+  strategy:
+    resources: {}
+  triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - restify
+      from:
+        kind: ImageStreamTag
+        name: "restify:latest"
+  replicas: 1
+  selector:
+    app: restify
+    deploymentconfig: restify
+  template:
+    metadata:
+      creationTimestamp: 
+      labels:
+        app: restify
+        deploymentconfig: restify
+    spec:
+      volumes:
+      - name: "restify-volume-1"
+        emptyDir: {}
+      containers:
+      - name: restify
+        image: library/restify:latest
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: DATABASE_SERVICE_NAME
+          value: mongodb
+        - name: MONGODB_DATABASE
+          value: restify-database
+        - name: MONGODB_PASSWORD
+          value: mongo-user-password
+        - name: MONGODB_USER
+          value: mongo-user-1
+        resources: {}
+        volumeMounts:
+        - name: "restify-volume-1"
+          mountPath: "/run"
+status: {}
+
+---
+kind: Route
+apiVersion: v1
+metadata:
+  name: restify
+  namespace: parks-app
+  labels:
+    app: restify
+spec:
+  to:
+    kind: Service
+    name: restify
+  port:
+    targetPort: '8080'
+status: {}
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: restify
+  namespace: parks-app
+  labels:
+    app: restify
+spec:
+  ports:
+  - name: 8080-tcp
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: restify
+    deploymentconfig: restify
+status:
+  loadBalancer: {}
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: mongodb
+  namespace: parks-app
+spec:
+  strategy:
+    type: Recreate
+  triggers:
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - mongodb-container
+      from:
+        kind: ImageStreamTag
+        name: mongodb:latest
+        namespace: openshift
+  - type: ConfigChange
+  replicas: 1
+  selector:
+    name: mongodb
+  template:
+    metadata:
+      labels:
+        name: mongodb
+    spec:
+      containers:
+      - name: mongodb-container
+        image: " "
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+        env:
+        - name: MONGODB_USER
+          value: mongo-user-1
+        - name: MONGODB_PASSWORD
+          value: mongo-user-password
+        - name: MONGODB_DATABASE
+          value: restify-database
+        - name: MONGODB_ADMIN_PASSWORD
+          value: moogo-admin-pass
+        volumeMounts:
+        - name: mongodb-data
+          mountPath: /data/db"
+        imagePullPolicy: Always
+      volumes:
+      - name: mongodb-data
+        persistentVolumeClaim:
+          claimName: mongodb-data-claim
+      restartPolicy: Always
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mongodb
+  namespace: parks-app
+spec:
+  ports:
+  - name: mongo
+    protocol: TCP
+    port: 27017
+    targetPort: 27017
+    nodePort: 0
+  selector:
+    name: mongodb
+  portalIP: ''
+  type: ClusterIP
+  sessionAffinity: None
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "mongodb-data-claim"
+  namespace: parks-app
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+

--- a/roles/robot-shop/defaults/main.yml
+++ b/roles/robot-shop/defaults/main.yml
@@ -8,8 +8,8 @@ pv_action: move
 pv_copy_method: filesystem
 quiesce: true
 stage: false
-storage_class: gp2
-oc_binary: "oc"
+src_storage_class: ""
+dst_storage_class: gp2
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/robot-shop/tasks/deploy.yml
+++ b/roles/robot-shop/tasks/deploy.yml
@@ -6,4 +6,4 @@
 - name: Deploy {{ migration_sample_name }} sample
   k8s:
     state : present
-    definition: "{{ lookup('file', '{{ migration_sample_files }}/manifest.yaml' )}}"
+    definition: "{{ lookup('template', 'manifest.yml' )}}"

--- a/roles/robot-shop/templates/manifest.yml
+++ b/roles/robot-shop/templates/manifest.yml
@@ -1,0 +1,763 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: robot-shop
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cart
+  labels:
+    service: cart
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: cart
+  template:
+    metadata:
+      labels:
+        service: cart
+    spec:
+      containers:
+      - name: cart
+        image: robotshop/rs-cart:latest
+        # agent networking access 
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: cart
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: catalogue
+  labels:
+    service: catalogue
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: catalogue
+  template:
+    metadata:
+      labels:
+        service: catalogue
+    spec:
+      containers:
+      - name: catalogue
+        image: robotshop/rs-catalogue:latest
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: catalogue
+  name: catalogue
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: catalogue
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: dispatch
+  labels:
+    service: dispatch
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: dispatch
+  template:
+    metadata:
+      labels:
+        service: dispatch
+    spec:
+      containers:
+      - name: dispatch
+        image: robotshop/rs-dispatch:latest
+        env:
+          # agent networking access
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dispatch
+  labels:
+    service: dispatch
+  namespace: robot-shop
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 55555
+    targetPort: 0
+  selector:
+    service: dispatch
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mongodb
+  labels:
+    service: mongodb
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mongodb
+  template:
+    metadata:
+      labels:
+        service: mongodb
+    spec:
+      containers:
+      - name: mongodb
+        image: robotshop/rs-mongodb:latest
+        ports:
+        - containerPort: 27017
+        volumeMounts:
+        - mountPath: "/data/db"
+          name: mongodb-volume
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      restartPolicy: Always
+      volumes:
+      - name: mongodb-volume
+        persistentVolumeClaim:
+          claimName: mongodb-volume-claim
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongodb-volume-claim
+  namespace: robot-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: mongodb
+  name: mongodb
+  namespace: robot-shop
+spec:
+  ports:
+  - name: mongo
+    port: 27017
+    targetPort: 27017
+  selector:
+    service: mongodb
+
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: mysql
+#  labels:
+#    service: mysql
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    service: mysql
+  strategy:
+    type: Recreate
+    recreateParams:
+      post:
+        failurePolicy: ignore
+        execNewPod:
+          containerName: mysql
+          volumes:
+            - mysql-scripts-volume
+          command:
+          - /bin/sh
+          - -c
+          - sleep 120 && zcat /tmp/mysql-init-scripts/10-dump.sql.gz | /opt/rh/rh-mysql57/root/bin/mysql --force -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -D $MYSQL_DATABASE -P 3306 && /opt/rh/rh-mysql57/root/bin/mysql -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -P 3306 < /tmp/mysql-init-scripts/20-ratings.sql && sleep 60
+          env:
+          - name: MYSQL_USER
+            value: shipping
+          - name: MYSQL_PASSWORD
+            value: secret
+          - name: MYSQL_DATABASE
+            value: cities
+  template:
+    metadata:
+      labels:
+        service: mysql
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: post-hook
+        imagePullPolicy: Always
+        image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
+        command:
+        - /bin/sh
+        - -c
+        - cp -r /tmp/post-scripts/* /tmp/mysql-init-scripts/ && sleep infinity
+        volumeMounts:
+        - mountPath: "/tmp/mysql-init-scripts/"
+          name: mysql-scripts-volume
+      - name: mysql
+        image: " "
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3306
+        env:
+        - name: MYSQL_USER
+          value: shipping
+        - name: MYSQL_PASSWORD
+          value: secret
+        - name: MYSQL_DATABASE
+          value: cities
+        - name: MYSQL_ROOT_PASSWORD
+          value: R00t@123
+        resources:
+          limits:
+            cpu: 200m
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        volumeMounts:
+        - mountPath: "/var/lib/mysql/data"
+          name: mysql-data-volume
+        - mountPath: "/tmp/mysql-init-scripts"
+          name: mysql-scripts-volume      
+      restartPolicy: Always
+      volumes:
+      - name: mysql-data-volume
+        persistentVolumeClaim:
+          claimName: mysql-data-volume-claim
+      - name: mysql-scripts-volume
+        persistentVolumeClaim:
+          claimName: mysql-scripts-volume-claim
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - mysql
+      from:
+        kind: ImageStreamTag
+        name: mysql:5.7
+        namespace: openshift
+    type: ImageChange
+  - type: ConfigChange
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-data-volume-claim
+  namespace: robot-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-scripts-volume-claim
+  namespace: robot-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: mysql
+  name: mysql
+  namespace: robot-shop
+spec:
+  ports:
+  - name: mysql
+    port: 3306
+    targetPort: 3306
+  selector:
+    service: mysql
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: payment
+  labels:
+    service: payment
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: payment
+  template:
+    metadata:
+      labels:
+        service: payment
+    spec:
+      containers:
+      - name: payment
+        image: docker.io/pranavgaikwad/robot-shop-payment:latest
+        # agent networking access
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  labels:
+    service: payment
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: payment
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    service: rabbitmq
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: rabbitmq
+  template:
+    metadata:
+      labels:
+        service: rabbitmq
+    spec:
+      containers:
+      - name: rabbitmq
+        image: rabbitmq:3.7-management-alpine
+        ports:
+        - containerPort: 5672
+        - containerPort: 15672
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    service: rabbitmq
+  namespace: robot-shop
+spec:
+  ports:
+  - name: tcp-amqp
+    port: 5672
+    targetPort: 5672
+  - name: http-management
+    port: 15672
+    targetPort: 15672
+  - name: tcp-epmd
+    port: 4369
+    targetPort: 4369
+  selector:
+    service: rabbitmq
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: ratings
+  labels:
+    service: ratings
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ratings
+  template:
+    metadata:
+      labels:
+        service: ratings
+    spec:
+      containers:
+      - name: ratings
+        image: docker.io/pranavgaikwad/robot-shop-ratings:latest
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  labels:
+    service: ratings
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: ratings
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    service: redis
+  name: redis
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: redis
+  template:
+    metadata:
+      labels:
+        service: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:4.0.6
+        ports:
+        - containerPort: 6379
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: "/data"
+          name: redis-volume
+      restartPolicy: Always
+      volumes:
+      - name: redis-volume
+        persistentVolumeClaim:
+          claimName: redis-volume-claim
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: robot-shop
+  name: redis-volume-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: redis
+  name: redis
+  namespace: robot-shop
+spec:
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+  selector:
+    service: redis
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    service: shipping
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: shipping
+  template:
+    metadata:
+      labels:
+        service: shipping
+    spec:
+      containers:
+      - name: shipping
+        image: robotshop/rs-shipping:latest
+        ports:
+        - containerPort: 8080
+        # it's Java it needs lots of memory
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 500Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    service: shipping
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: shipping
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: user
+  labels:
+    service: user
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: user
+  template:
+    metadata:
+      labels:
+        service: user
+    spec:
+      containers:
+      - name: user
+        image: robotshop/rs-user:latest
+        env:
+          # agent networking access
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user
+  labels:
+    service: user
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: user
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: web
+  labels:
+    service: web
+  namespace: robot-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: web
+  template:
+    metadata:
+      labels:
+        service: web
+    spec:
+      containers:
+      - name: web
+        image: docker.io/pranavgaikwad/robot-shop-nginx:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        # securityContext:
+        #   privileged: true
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: front-end
+  namespace: robot-shop
+spec:
+  path: "/"
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: web
+
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    service: web
+  namespace: robot-shop
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: web
+  type: LoadBalancer
+

--- a/roles/sock-shop/defaults/main.yml
+++ b/roles/sock-shop/defaults/main.yml
@@ -8,8 +8,8 @@ pv_action: move
 pv_copy_method: filesystem
 quiesce: true
 stage: false
-storage_class: gp2
-oc_binary: "oc"
+src_storage_class: ""
+dst_storage_class: gp2
 with_deploy: true
 with_migrate: true
 with_cleanup: true

--- a/roles/sock-shop/tasks/deploy.yml
+++ b/roles/sock-shop/tasks/deploy.yml
@@ -6,4 +6,4 @@
 - name: Deploy {{ migration_sample_name }} sample
   k8s:
     state : present
-    definition: "{{ lookup('file', '{{ migration_sample_files }}/manifest.yaml' )}}"
+    definition: "{{ lookup('template', 'manifest.yml' )}}"

--- a/roles/sock-shop/templates/manifest.yml
+++ b/roles/sock-shop/templates/manifest.yml
@@ -1,0 +1,1131 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sock-shop
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sock-shop
+  namespace: sock-shop
+  labels:
+    component: sock-shop
+---
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: sock-shop
+readOnlyRootFilesystem: true
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- '*'
+users:
+- system:admin
+- system:serviceaccount:sock-shop:sock-shop
+requiredDropCapabilities:
+- all
+defaultAddCapabilities:
+- CHOWN
+- SETGID
+- SETUID
+- NET_BIND_SERVICE
+- DAC_OVERRIDE
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: carts-db
+  labels:
+    name: carts-db
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: carts-db
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: carts-db
+        image: mongo
+        ports:
+        - name: mongo
+          containerPort: 27017
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /data/db
+          name: carts-data-volume
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+        - name: carts-data-volume
+          persistentVolumeClaim:
+            claimName: carts-data-volume-claim
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: carts-data-volume-claim
+  namespace: sock-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: carts-db
+  labels:
+    name: carts-db
+  namespace: sock-shop
+spec:
+  ports:
+  - port: 27017
+    targetPort: 27017
+  selector:
+    name: carts-db
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: carts
+  labels:
+    name: carts
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: carts
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: carts
+        image: weaveworksdemos/carts:0.4.8
+        env:
+         - name: ZIPKIN
+           value: zipkin.jaeger.svc.cluster.local
+         - name: JAVA_OPTS
+           value: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
+        resources:
+          limits:
+            cpu: 300m
+            memory: 500Mi
+          requests:
+            cpu: 300m
+            memory: 500Mi
+        ports:
+        - containerPort: 80
+        # securityContext:
+        #   runAsNonRoot: true
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - NET_BIND_SERVICE
+        #   readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: carts
+  labels:
+    name: carts
+  namespace: sock-shop
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    name: carts
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalogue-db-config
+  namespace: sock-shop
+data:
+  dump.sql: "CREATE TABLE IF NOT EXISTS sock (\n\tsock_id
+    varchar(40) NOT NULL, \n\tname varchar(20), \n\tdescription varchar(200), \n\tprice
+    float, \n\tcount int, \n\timage_url_1 varchar(40), \n\timage_url_2 varchar(40),
+    \n\tPRIMARY KEY(sock_id)\n);\n\nCREATE TABLE IF NOT EXISTS tag (\n\ttag_id MEDIUMINT
+    NOT NULL AUTO_INCREMENT, \n\tname varchar(20), \n\tPRIMARY KEY(tag_id)\n);\n\nCREATE
+    TABLE IF NOT EXISTS sock_tag (\n\tsock_id varchar(40), \n\ttag_id MEDIUMINT NOT
+    NULL, \n\tFOREIGN KEY (sock_id) \n\t\tREFERENCES sock(sock_id), \n\tFOREIGN KEY(tag_id)\n\t\tREFERENCES
+    tag(tag_id)\n);\n\nINSERT INTO sock VALUES (\"6d62d909-f957-430e-8689-b5129c0bb75e\",
+    \"Weave special\", \"Limited issue Weave socks.\", 17.15, 33, \"/catalogue/images/weave1.jpg\",
+    \"/catalogue/images/weave2.jpg\");\nINSERT INTO sock VALUES (\"a0a4f044-b040-410d-8ead-4de0446aec7e\",
+    \"Nerd leg\", \"For all those leg lovers out there. A perfect example of a swivel
+    chair trained calf. Meticulously trained on a diet of sitting and Pina Coladas.
+    Phwarr...\", 7.99, 115, \"/catalogue/images/bit_of_leg_1.jpeg\", \"/catalogue/images/bit_of_leg_2.jpeg\");\nINSERT
+    INTO sock VALUES (\"808a2de1-1aaa-4c25-a9b9-6612e8f29a38\", \"Crossed\", \"A mature
+    sock, crossed, with an air of nonchalance.\",  17.32, 738, \"/catalogue/images/cross_1.jpeg\",
+    \"/catalogue/images/cross_2.jpeg\");\nINSERT INTO sock VALUES (\"510a0d7e-8e83-4193-b483-e27e09ddc34d\",
+    \"SuperSport XL\", \"Ready for action. Engineers: be ready to smash that next
+    bug! Be ready, with these super-action-sport-masterpieces. This particular engineer
+    was chased away from the office with a stick.\",  15.00, 820, \"/catalogue/images/puma_1.jpeg\",
+    \"/catalogue/images/puma_2.jpeg\");\nINSERT INTO sock VALUES (\"03fef6ac-1896-4ce8-bd69-b798f85c6e0b\",
+    \"Holy\", \"Socks fit for a Messiah. You too can experience walking in water with
+    these special edition beauties. Each hole is lovingly proggled to leave smooth
+    edges. The only sock approved by a higher power.\",  99.99, 1, \"/catalogue/images/holy_1.jpeg\",
+    \"/catalogue/images/holy_2.jpeg\");\nINSERT INTO sock VALUES (\"d3588630-ad8e-49df-bbd7-3167f7efb246\",
+    \"YouTube.sock\", \"We were not paid to sell this sock. It's just a bit geeky.\",
+    \ 10.99, 801, \"/catalogue/images/youtube_1.jpeg\", \"/catalogue/images/youtube_2.jpeg\");\nINSERT
+    INTO sock VALUES (\"819e1fbf-8b7e-4f6d-811f-693534916a8b\", \"Figueroa\", \"enim
+    officia aliqua excepteur esse deserunt quis aliquip nostrud anim\",  14, 808,
+    \"/catalogue/images/WAT.jpg\", \"/catalogue/images/WAT2.jpg\");\nINSERT INTO sock
+    VALUES (\"zzz4f044-b040-410d-8ead-4de0446aec7e\", \"Classic\", \"Keep it simple.\",
+    \ 12, 127, \"/catalogue/images/classic.jpg\", \"/catalogue/images/classic2.jpg\");\nINSERT
+    INTO sock VALUES (\"3395a43e-2d88-40de-b95f-e00e1502085b\", \"Colourful\", \"proident
+    occaecat irure et excepteur labore minim nisi amet irure\",  18, 438, \"/catalogue/images/colourful_socks.jpg\",
+    \"/catalogue/images/colourful_socks.jpg\");\nINSERT INTO sock VALUES (\"837ab141-399e-4c1f-9abc-bace40296bac\",
+    \"Cat socks\", \"consequat amet cupidatat minim laborum tempor elit ex consequat
+    in\",  15, 175, \"/catalogue/images/catsocks.jpg\", \"/catalogue/images/catsocks2.jpg\");\n\nINSERT
+    INTO tag (name) VALUES (\"brown\");\nINSERT INTO tag (name) VALUES (\"geek\");\nINSERT
+    INTO tag (name) VALUES (\"formal\");\nINSERT INTO tag (name) VALUES (\"blue\");\nINSERT
+    INTO tag (name) VALUES (\"skin\");\nINSERT INTO tag (name) VALUES (\"red\");\nINSERT
+    INTO tag (name) VALUES (\"action\");\nINSERT INTO tag (name) VALUES (\"sport\");\nINSERT
+    INTO tag (name) VALUES (\"black\");\nINSERT INTO tag (name) VALUES (\"magic\");\nINSERT
+    INTO tag (name) VALUES (\"green\");\n\nINSERT INTO sock_tag VALUES (\"6d62d909-f957-430e-8689-b5129c0bb75e\",
+    \"2\");\nINSERT INTO sock_tag VALUES (\"6d62d909-f957-430e-8689-b5129c0bb75e\",
+    \"9\");\nINSERT INTO sock_tag VALUES (\"a0a4f044-b040-410d-8ead-4de0446aec7e\",
+    \"4\");\nINSERT INTO sock_tag VALUES (\"a0a4f044-b040-410d-8ead-4de0446aec7e\",
+    \"5\");\nINSERT INTO sock_tag VALUES (\"808a2de1-1aaa-4c25-a9b9-6612e8f29a38\",
+    \"4\");\nINSERT INTO sock_tag VALUES (\"808a2de1-1aaa-4c25-a9b9-6612e8f29a38\",
+    \"6\");\nINSERT INTO sock_tag VALUES (\"808a2de1-1aaa-4c25-a9b9-6612e8f29a38\",
+    \"7\");\nINSERT INTO sock_tag VALUES (\"808a2de1-1aaa-4c25-a9b9-6612e8f29a38\",
+    \"3\");\nINSERT INTO sock_tag VALUES (\"510a0d7e-8e83-4193-b483-e27e09ddc34d\",
+    \"8\");\nINSERT INTO sock_tag VALUES (\"510a0d7e-8e83-4193-b483-e27e09ddc34d\",
+    \"9\");\nINSERT INTO sock_tag VALUES (\"510a0d7e-8e83-4193-b483-e27e09ddc34d\",
+    \"3\");\nINSERT INTO sock_tag VALUES (\"03fef6ac-1896-4ce8-bd69-b798f85c6e0b\",
+    \"10\");\nINSERT INTO sock_tag VALUES (\"03fef6ac-1896-4ce8-bd69-b798f85c6e0b\",
+    \"7\");\nINSERT INTO sock_tag VALUES (\"d3588630-ad8e-49df-bbd7-3167f7efb246\",
+    \"2\");\nINSERT INTO sock_tag VALUES (\"d3588630-ad8e-49df-bbd7-3167f7efb246\",
+    \"3\");\nINSERT INTO sock_tag VALUES (\"819e1fbf-8b7e-4f6d-811f-693534916a8b\",
+    \"3\");\nINSERT INTO sock_tag VALUES (\"819e1fbf-8b7e-4f6d-811f-693534916a8b\",
+    \"11\");\nINSERT INTO sock_tag VALUES (\"819e1fbf-8b7e-4f6d-811f-693534916a8b\",
+    \"4\");\nINSERT INTO sock_tag VALUES (\"zzz4f044-b040-410d-8ead-4de0446aec7e\",
+    \"1\");\nINSERT INTO sock_tag VALUES (\"zzz4f044-b040-410d-8ead-4de0446aec7e\",
+    \"11\");\nINSERT INTO sock_tag VALUES (\"3395a43e-2d88-40de-b95f-e00e1502085b\",
+    \"1\");\nINSERT INTO sock_tag VALUES (\"3395a43e-2d88-40de-b95f-e00e1502085b\",
+    \"4\");\nINSERT INTO sock_tag VALUES (\"837ab141-399e-4c1f-9abc-bace40296bac\",
+    \"1\");\nINSERT INTO sock_tag VALUES (\"837ab141-399e-4c1f-9abc-bace40296bac\",
+    \"11\");\nINSERT INTO sock_tag VALUES (\"837ab141-399e-4c1f-9abc-bace40296bac\",
+    \"3\");\n\n\n\n\n"
+
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: 'true'
+  name: catalogue-db
+  namespace: sock-shop
+spec:
+  replicas: 1
+  selector:
+    name: catalogue-db
+  strategy:
+    type: Recreate
+    recreateParams:
+      post:
+        failurePolicy: ignore
+        execNewPod:
+          volumes:
+            - catalogue-db-init-volume
+          containerName: catalogue-db
+          command:
+          - /bin/sh
+          - -c
+          - hostname && sleep 60 && /opt/rh/rh-mysql57/root/usr/bin/mysql --force -h $CATALOGUE_DB_SERVICE_HOST -u $MYSQL_USER -D $MYSQL_DATABASE -p$MYSQL_PASSWORD -P 3306 < /mysql-init/dump.sql
+  template:
+    metadata:
+      labels:
+        name: catalogue-db
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_USER
+          value: catalogue_user
+        - name: MYSQL_PASSWORD
+          value: default_password
+        - name: MYSQL_DATABASE
+          value: socksdb
+        image: " "
+        imagepullpolicy: always
+        name: catalogue-db
+        ports:
+        - containerPort: 3306
+        resources:
+          limits:
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: "/var/lib/mysql/data"
+          name: catalogue-db-data-volume
+        - mountPath: "/mysql-init"
+          name: catalogue-db-init-volume
+      volumes:
+      - name: catalogue-db-data-volume
+        persistentVolumeClaim:
+          claimName: catalogue-data-volume-claim
+      - name: catalogue-db-init-volume
+        configMap:
+          name: catalogue-db-config
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - catalogue-db
+      from:
+        kind: ImageStreamTag
+        name: mysql:5.7
+        namespace: openshift
+    type: ImageChange
+  - type: ConfigChange
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: catalogue-data-volume-claim
+  namespace: sock-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalogue-db
+  labels:
+    name: catalogue-db
+  namespace: sock-shop
+spec:
+  ports:
+  - port: 3306
+    targetPort: 3306
+  selector:
+    name: catalogue-db
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: catalogue
+  labels:
+    name: catalogue
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: catalogue
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: catalogue
+        image: weaveworksdemos/catalogue:0.3.5
+        command: ["/app"]
+        args:
+        - -port=80
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+        # securityContext:
+        #   runAsNonRoot: true
+        #   runAsUser: 10001
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - NET_BIND_SERVICE
+        #   readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalogue
+  labels:
+    name: catalogue
+  namespace: sock-shop
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    name: catalogue
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: front-end
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: front-end
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: front-end
+        image: weaveworksdemos/front-end:0.3.12
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        ports:
+        - containerPort: 8079
+        env:
+        - name: SESSION_REDIS
+          value: "true"
+        # securityContext:
+        #   runAsNonRoot: true
+        #   runAsUser: 10001
+        #   capabilities:
+        #     drop:
+        #       - all
+        #   readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8079
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8079
+          initialDelaySeconds: 30
+          periodSeconds: 3
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: front-end
+  namespace: sock-shop
+spec:
+  path: "/" 
+  port:
+    targetPort: 8079
+  to:
+    kind: Service
+    name: front-end
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: front-end
+  labels:
+    name: front-end
+  namespace: sock-shop
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8079
+    nodePort: 30001
+  selector:
+    name: front-end
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: orders-db
+  labels:
+    name: orders-db
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: orders-db
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: orders-db
+        image: mongo
+        ports:
+        - name: mongo
+          containerPort: 27017
+        # securityContext:
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - CHOWN
+        #       - SETGID
+        #       - SETUID
+        #   readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /data/db
+          name: orders-data-volume
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+        - name: orders-data-volume
+          persistentVolumeClaim:
+            claimName: orders-data-volume-claim
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: orders-data-volume-claim
+  namespace: sock-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orders-db
+  labels:
+    name: orders-db
+  namespace: sock-shop
+spec:
+  ports:
+  - port: 27017
+    targetPort: 27017
+  selector:
+    name: orders-db
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: orders
+  labels:
+    name: orders
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: orders
+    spec:
+      serviceAccountName: sock-shop      
+      containers:
+      - name: orders
+        image: weaveworksdemos/orders:0.4.7
+        env:
+         - name: ZIPKIN
+           value: zipkin.jaeger.svc.cluster.local
+         - name: JAVA_OPTS
+           value: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 200m
+            memory: 500Mi
+        ports:
+        - containerPort: 80
+        # securityContext:
+        #   runAsNonRoot: true
+        #   runAsUser: 10001
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - NET_BIND_SERVICE
+        #   readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orders
+  labels:
+    name: orders
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    name: orders
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: payment
+  labels:
+    name: payment
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: payment
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: payment
+        image: weaveworksdemos/payment:0.4.3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 99m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+        # securityContext:
+        #   runAsNonRoot: true
+        #   runAsUser: 10001
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - NET_BIND_SERVICE
+        #   readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  labels:
+    name: payment
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    name: payment
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: queue-master
+  labels:
+    name: queue-master
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: queue-master
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: queue-master
+        image: weaveworksdemos/queue-master:0.3.1
+        env:
+         - name: ZIPKIN
+           value: zipkin.jaeger.svc.cluster.local
+         - name: JAVA_OPTS
+           value: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
+        resources:
+          limits:
+            cpu: 300m
+            memory: 500Mi
+          requests:
+            cpu: 300m
+            memory: 500Mi
+        ports:
+        - containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: queue-master
+  labels:
+    name: queue-master
+  annotations:
+    prometheus.io/path: "/prometheus"
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    name: queue-master
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    name: rabbitmq
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: rabbitmq
+      annotations:
+        prometheus.io/scrape: "false"
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: rabbitmq
+        image: rabbitmq:3.6.8-management
+        ports:
+        - containerPort: 15672
+          name: management
+        - containerPort: 5672
+          name: rabbitmq
+        # securityContext:
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - CHOWN
+        #       - SETGID
+        #       - SETUID
+        #       - DAC_OVERRIDE
+        #   readOnlyRootFilesystem: true
+      - name: rabbitmq-exporter
+        image: kbudde/rabbitmq-exporter
+        ports:
+        - containerPort: 9090
+          name: exporter
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    name: rabbitmq
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 5672
+    name: rabbitmq
+    targetPort: 5672
+  - port: 9090
+    name: exporter
+    targetPort: exporter
+    protocol: TCP
+  selector:
+    name: rabbitmq
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: session-db
+  labels:
+    name: session-db
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: session-db
+      annotations:
+        prometheus.io.scrape: "false"
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: session-db
+        image: redis:alpine
+        ports:
+        - name: redis
+          containerPort: 6379
+        # securityContext:
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - CHOWN
+        #       - SETGID
+        #       - SETUID
+        #   readOnlyRootFilesystem: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: session-db
+  labels:
+    name: session-db
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+    targetPort: 6379
+  selector:
+    name: session-db
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    name: shipping
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: shipping
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: shipping
+        image: weaveworksdemos/shipping:0.4.8
+        env:
+         - name: ZIPKIN
+           value: zipkin.jaeger.svc.cluster.local
+         - name: JAVA_OPTS
+           value: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
+        resources:
+          limits:
+            cpu: 300m
+            memory: 500Mi
+          requests:
+            cpu: 300m
+            memory: 500Mi
+        ports:
+        - containerPort: 80
+        # securityContext:
+        #   runAsNonRoot: true
+        #   runAsUser: 10001
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - NET_BIND_SERVICE
+        #   readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    name: shipping
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    name: shipping
+
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: user-db
+  labels:
+    name: user-db
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: user-db
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: user-db
+        image: weaveworksdemos/user-db:0.3.0
+        ports:
+        - name: mongo
+          containerPort: 27017  
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /data/db-users
+          name: user-data-volume
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+        - name: user-data-volume
+          persistentVolumeClaim:
+            claimName: user-data-volume-claim
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: user-data-volume-claim
+  namespace: sock-shop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ src_storage_class | quote }}
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-db
+  labels:
+    name: user-db
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 27017
+    targetPort: 27017
+  selector:
+    name: user-db
+
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: user
+  labels:
+    name: user
+  namespace: sock-shop
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: user
+    spec:
+      serviceAccountName: sock-shop
+      containers:
+      - name: user
+        image: weaveworksdemos/user:0.4.7
+        resources:
+          limits:
+            cpu: 300m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+        env:
+        - name: mongo
+          value: user-db:27017
+        # securityContext:
+        #   runAsNonRoot: true
+        #   runAsUser: 10001
+        #   capabilities:
+        #     drop:
+        #       - all
+        #     add:
+        #       - NET_BIND_SERVICE
+        #   readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 300
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 180
+          periodSeconds: 3
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user
+  labels:
+    name: user
+  namespace: sock-shop
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    name: user
+
+


### PR DESCRIPTION
- Implement handling of storage class via two variables : 

src_storage_class : This is the storage class that will be requested during deployment of the tests on source cluster
dst_storage_class : This is the storage class that will be requested during migration at the destination cluster

**_Note:_**
By default, the src_storage_class is set to empty on all test roles, which results into NFS PVs being provisioned. To see examples in how to use these variables check the e2e_mig_samples.yml playbook.
By default, the dst_storage_class is set to gp2 on all test roles, adjust as necessary on playbooks or via "-e".

- Modify parks-app example to perform a copy migration from glusterfs to EBS (gp2)
- Import all manifests from mig-demo-apps in order to manipulate storage class and template accordingly
- Set oc_binary as a default variable instead of including on each role

This PR depends on : https://github.com/fusor/mig-ci/pull/121