### PR TITLE
Implement 4.x snapshot e2e testing

### DIFF
--- a/e2e_mig_samples_4.yml
+++ b/e2e_mig_samples_4.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  roles:
+    - { role: migration_prepare, tags: ["always"] }
+    - { role: mssql-app, tags: ["mssql-app"], pv_action: 'copy', pv_copy_method: 'snapshot', stage: 'true', src_storage_class: 'gp2', dst_storage_class: 'gp2' }
+    - { role: sock-shop, tags: ["sock-shop"], pv_action: 'copy', pv_copy_method: 'snapshot', src_storage_class: 'gp2', dst_storage_class: 'gp2' }
+    - { role: parks-app, tags: ["parks-app"], pv_action: 'copy', pv_copy_method: 'snapshot', src_storage_class: 'gp2', dst_storage_class: 'gp2' }
+    - { role: robot-shop, tags: ["robot-shop"], pv_action: 'copy', pv_copy_method: 'snapshot', stage: 'true', src_storage_class: 'gp2', dst_storage_class: 'gp2' }
+  vars_files:
+    - "{{ playbook_dir }}/config/mig_controller.yml"
+    - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/parks-app/tasks/deploy.yml
+++ b/roles/parks-app/tasks/deploy.yml
@@ -7,14 +7,15 @@
   k8s:
     state : present
     definition: "{{ lookup('template', 'manifest.yml' )}}"
+    wait: yes
 
 - name: Check s2i build {{ migration_sample_name }} restify is completed
   k8s_facts:
     kind: Build
-    api_version: v1
+    api_version: build.openshift.io/v1
     namespace: "{{ namespace }}"
     label_selectors: "app=restify"
   register: s2i
   until: s2i.resources[0].get("status", {}).get("phase", "") == "Complete"
-  retries: 60
-  delay: 5
+  retries: 30
+  delay: 10


### PR DESCRIPTION
- Use a new 4.x playbook to test mig controller snapshot feature on gp2
  volumes
- parks-app: fix k8s API issue with deployments on OCP 4.x
- Playbook is meant to be executed for 4.x -> 4.x migrations only