### PR TITLE
Add ocp-25000 ocp-25021 ocp-25090 ocp-25212  ocp-24997 test roles

### DIFF
--- a/e2e_destroy_all.yml
+++ b/e2e_destroy_all.yml
@@ -14,3 +14,8 @@
         - parks-app
         - mssql-example
         - mediawiki
+        - ocp-25000-sets
+        - ocp-25021-cronjob
+        - ocp-25090-jobs
+        - ocp-25212-initcont
+        - ocp-24997-confmap

--- a/e2e_mig_samples.yml
+++ b/e2e_mig_samples.yml
@@ -6,6 +6,11 @@
     - { role: robot-shop, tags: ["robot-shop"] }
     - { role: parks-app, tags: ["parks-app"], pv_action: 'copy', src_storage_class: 'glusterfs-storage' }
     - { role: mediawiki, tags: ["mediawiki"], pv_action: 'copy', src_storage_class: 'glusterfs-storage', dst_storage_class: 'csi-cephfs' }
+    - { role: ocp-25000-sets, tags: ["ocp-25000-sets", "ocp"] }
+    - { role: ocp-25021-cronjob, tags: ["never", "ocp-25021-cronjob"] }
+    - { role: ocp-25090-jobs, tags: ["ocp-25090-jobs", "ocp"] }
+    - { role: ocp-25212-initcont, tags: ["ocp-25212-initcont", "ocp"] }
+    - { role: ocp-24997-confmap, tags: ["ocp-24997-confmap", "ocp"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/e2e_run_all.yml
+++ b/e2e_run_all.yml
@@ -8,6 +8,11 @@
     - { role: parks-app, tags: ["parks-app"] }
     - { role: mssql-app, tags: ["mssql-app"] }
     - { role: mediawiki, tags: ["mediawiki"] }
+    - { role: ocp-25000-sets, tags: ["ocp-25000-sets", "ocp"] }
+    - { role: ocp-25021-cronjob, tags: ["never", "ocp-25021-cronjob"] }
+    - { role: ocp-25090-jobs, tags: ["ocp-25090-jobs", "ocp"] }
+    - { role: ocp-25212-initcont, tags: ["ocp-25212-initcont", "ocp"] }
+    - { role: ocp-24997-confmap, tags: ["ocp-24997-confmap", "ocp"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/migration_getfacts/defaults/main.yml
+++ b/roles/migration_getfacts/defaults/main.yml
@@ -1,0 +1,4 @@
+apis:
+  cronjob:
+    default: "batch/v1beta1"
+    "3.7": "batch/v2alpha1"

--- a/roles/migration_getfacts/tasks/main.yml
+++ b/roles/migration_getfacts/tasks/main.yml
@@ -1,0 +1,35 @@
+- name: Get cluster version
+  block:
+  - name: Check cluster version for 4.x
+    k8s_facts:
+      kind: ClusterVersion
+    register: cv
+  
+  - name: set 4.x version
+    set_fact:
+       oc_version: "{{ cv.resources[0].status.desired.version | regex_search('^[0-9]\\.[0-9]+')}}"
+    when: cv.resources | length > 0
+
+  - debug: msg={{ oc_version }}
+    when: cv.resources | length > 0
+
+  - fail:
+      msg: "Ocp is not a 4.x cluster"
+    when: cv.resources | length == 0
+
+  rescue:
+  - name: Cluster is not 4.x. Checking for 3.x version.
+    shell: "{{ oc_binary }} version"
+    register: cmdver
+  - name: Set  version for 3.x
+    set_fact:
+      oc_version: "{{ cmdver.stdout | regex_search('openshift v[0-9]\\.[0-9]+') | replace('openshift v', '')  }}"
+
+  - debug: msg={{ oc_version }}
+
+
+- name: Set apis
+  set_fact:
+    cronjob_api: "{{ apis.cronjob.get(oc_version, apis.cronjob.get('default')) }}"
+
+- debug: msg={{ cronjob_api }}

--- a/roles/migration_run/defaults/main.yml
+++ b/roles/migration_run/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-mig_velero_timeout: 120
+mig_velero_timeout: 10

--- a/roles/ocp-24997-confmap/defaults/main.yml
+++ b/roles/ocp-24997-confmap/defaults/main.yml
@@ -1,0 +1,15 @@
+namespace: ocp-24997-confmap
+
+confmap_name: redis-config
+app_name: redis
+
+migration_sample_name: ocp-24997-confmap
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: true

--- a/roles/ocp-24997-confmap/tasks/deploy.yml
+++ b/roles/ocp-24997-confmap/tasks/deploy.yml
@@ -1,0 +1,21 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Deploy configuration map
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'configmap.yml.j2' )}}"
+
+- name: Deploy redis appliation
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment-redis.yml.j2' )}}"

--- a/roles/ocp-24997-confmap/tasks/main.yml
+++ b/roles/ocp-24997-confmap/tasks/main.yml
@@ -1,0 +1,22 @@
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate.yml
+  when: with_validate|bool
+

--- a/roles/ocp-24997-confmap/tasks/migrate.yml
+++ b/roles/ocp-24997-confmap/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-24997-confmap/tasks/track.yml
+++ b/roles/ocp-24997-confmap/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-24997-confmap/tasks/validate.yml
+++ b/roles/ocp-24997-confmap/tasks/validate.yml
@@ -1,0 +1,32 @@
+- name: Check config map 
+  k8s_facts:
+    kind: ConfigMap
+    namespace: "{{ namespace }}"
+    name: "{{ confmap_name }}"
+  register: config_map
+  until: (config_map.resources | length > 0) and (config_map.resources[0].data.get("redis-config", "") != "")
+  retries: 30
+
+- name: Check redis app 
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors:
+    - "app=={{ app_name }}"
+    field_selectors:
+    - status.phase==Running
+  register: redis
+  until: redis.resources | length > 0
+  retries: 30
+
+- name: Verify max memory configuration
+  shell: "{{ oc_binary }} -n {{ namespace }} rsh {{ redis.resources[0].metadata.name }} redis-cli CONFIG GET maxmemory"
+  register: memory_command
+  until: (memory_command.stdout is search( "maxmemory" )) and  (memory_command.stdout is search( "2097152" )) 
+  retries: 5
+
+- name: Verify memory policy configuration
+  shell: "{{ oc_binary }} -n {{ namespace }} rsh {{ redis.resources[0].metadata.name }} redis-cli CONFIG GET maxmemory-policy"
+  register: memory_command
+  until: (memory_command.stdout is search( "maxmemory-policy" )) and  (memory_command.stdout is search( "allkeys-lru" ))
+  retries: 5

--- a/roles/ocp-24997-confmap/templates/configmap.yml.j2
+++ b/roles/ocp-24997-confmap/templates/configmap.yml.j2
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  redis-config: "maxmemory 2mb  \nmaxmemory-policy allkeys-lru\n"
+kind: ConfigMap
+metadata:
+  name: {{ confmap_name }}

--- a/roles/ocp-24997-confmap/templates/deployment-redis.yml.j2
+++ b/roles/ocp-24997-confmap/templates/deployment-redis.yml.j2
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: {{ app_name }}
+spec:
+  replicas: 1
+  selector:
+    app: {{ app_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+    spec:
+      containers:
+      - name:  {{ app_name }}
+        image: docker.io/redis:3.2
+        args: ["redis-server","/redis-master/redis.conf"]
+        env:
+        - name: MASTER
+          value: "true"
+        ports:
+        - containerPort: 6379
+        resources:
+          limits:
+            cpu: "0.1"
+        volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+        - mountPath: /redis-master
+          name: config
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ confmap_name }}
+            items:
+            - key: redis-config
+              path: redis.conf
+

--- a/roles/ocp-25000-sets/defaults/main.yml
+++ b/roles/ocp-25000-sets/defaults/main.yml
@@ -1,0 +1,23 @@
+namespace: ocp-25000-sets
+
+daemonset:
+  app_name: hello-daemonset
+
+replicaset:
+  app_name: frontend
+  replicas: 3
+
+statefulset:
+  app_name: hello
+  replicas: 1
+
+migration_sample_name: ocp-25000-sets
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: true

--- a/roles/ocp-25000-sets/tasks/deploy.yml
+++ b/roles/ocp-25000-sets/tasks/deploy.yml
@@ -1,0 +1,35 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} adm new-project {{ namespace }} --node-selector=''"
+  when: ns.resources | length == 0
+
+- name: Deploy daemonset
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment-daemonset.yml.j2' )}}"
+  vars:
+    app_name: "{{ daemonset.app_name }}"
+
+- name: Deploy replicaset
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment-replicaset.yml.j2' )}}"
+  vars:
+    app_name: "{{ replicaset.app_name }}"
+    replicas: "{{ replicaset.replicas }}"
+
+- name: Deploy statefulset
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment-statefulset.yml.j2' )}}"
+  vars:
+    app_name: "{{ statefulset.app_name }}"
+    replicas: "{{ statefulset.replicas }}"

--- a/roles/ocp-25000-sets/tasks/main.yml
+++ b/roles/ocp-25000-sets/tasks/main.yml
@@ -1,0 +1,22 @@
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate.yml
+  when: with_validate|bool
+

--- a/roles/ocp-25000-sets/tasks/migrate.yml
+++ b/roles/ocp-25000-sets/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-25000-sets/tasks/track.yml
+++ b/roles/ocp-25000-sets/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-25000-sets/tasks/validate.yml
+++ b/roles/ocp-25000-sets/tasks/validate.yml
@@ -1,0 +1,31 @@
+- name: Check daemon set
+  k8s_facts:
+    api_version: extensions/v1beta1
+    kind: DaemonSet
+    namespace: "{{ namespace }}"
+    name: "{{ daemonset.app_name }}"
+  register: ds
+  until: ds.resources | length > 0 and ds.resources[0].status.numberMisscheduled is defined and ds.resources[0].status.numberMisscheduled == 0
+  retries: 30
+
+- name: Check replicaset
+  k8s_facts:
+    api_version: extensions/v1beta1
+    kind: ReplicaSet
+    namespace: "{{ namespace }}"
+    name: "{{ replicaset.app_name }}"
+  register: rs
+  until: rs.resources | length > 0 and rs.resources[0].status.availableReplicas is defined and rs.resources[0].status.availableReplicas == replicaset.replicas
+  retries: 30
+
+- name: Check  statefulset
+  k8s_facts:
+    api_version: apps/v1beta1
+    kind: StatefulSet
+    namespace: "{{ namespace }}"
+    name: "{{ statefulset.app_name }}"
+  register: sts
+  until: sts.resources | length > 0 and sts.resources[0].status.readyReplicas is defined and sts.resources[0].status.readyReplicas == statefulset.replicas
+  retries: 30
+
+#TODO: add checks on labels, annotations and resources.

--- a/roles/ocp-25000-sets/templates/deployment-daemonset.yml.j2
+++ b/roles/ocp-25000-sets/templates/deployment-daemonset.yml.j2
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ app_name }}
+spec:
+  selector:
+      matchLabels:
+        name: {{ app_name }}
+  template:
+    metadata:
+      labels:
+        name: {{ app_name }}
+    spec:
+      containers:
+      - image: openshift/hello-openshift
+        imagePullPolicy: Always
+        name: registry
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+      serviceAccount: default
+      terminationGracePeriodSeconds: 10

--- a/roles/ocp-25000-sets/templates/deployment-replicaset.yml.j2
+++ b/roles/ocp-25000-sets/templates/deployment-replicaset.yml.j2
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: {{ app_name }}
+spec:
+  replicas: {{ replicas }}
+  selector:
+    matchLabels:
+      tier: {{ app_name }}
+    matchExpressions:
+      - {key: tier, operator: In, values: [{{ app_name }}]}
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: {{ app_name }}
+    spec:
+      containers:
+      - name: hello-openshift
+        image: openshift/hello-openshift
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        ports:
+        - containerPort: 8080

--- a/roles/ocp-25000-sets/templates/deployment-statefulset.yml.j2
+++ b/roles/ocp-25000-sets/templates/deployment-statefulset.yml.j2
@@ -1,0 +1,31 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  annotations:
+    note: this is my example annotation, happy boy
+  labels:
+    app: {{ app_name }}
+    name: {{ app_name }}
+  name: {{ app_name }}
+spec:
+  replicas: {{ replicas }}
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+  serviceName: {{ app_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+    spec:
+      containers:
+      - image: aosqe/hello-openshift
+        name: {{ app_name }}
+        ports:
+        - containerPort: 8080
+          name: web
+          protocol: TCP
+        resources:
+          limits:
+            memory: 256Mi
+      restartPolicy: Always

--- a/roles/ocp-25021-cronjob/defaults/main.yml
+++ b/roles/ocp-25021-cronjob/defaults/main.yml
@@ -1,0 +1,19 @@
+namespace: ocp-25021-cronjob
+
+int_app_name: internal-cronjob
+ext_app_name: external-cronjob
+
+internal_image_name: internal-alpine
+internal_image_tag: int
+external_image_name: docker.io/alpine
+
+migration_sample_name: ocp-25021-cronjob
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: false

--- a/roles/ocp-25021-cronjob/tasks/deploy.yml
+++ b/roles/ocp-25021-cronjob/tasks/deploy.yml
@@ -1,0 +1,34 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Import image to imagestream
+  shell: "{{ oc_binary }} -n {{ namespace }}  import-image {{ internal_image_name }}:{{ internal_image_tag }} --from {{ external_image_name }} --confirm"
+
+# Cron job will probably fail in 3.7 because of the api version. TODO: Adapt this to 3.7 too.
+- name: Deploy cronjob using external image
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    app_name: "{{ ext_app_name }}"
+    docker_image: docker.io/alpine
+
+
+- name: Deploy cronjob using internal image
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    app_name: "{{ int_app_name }}"
+    docker_image: "docker-registry.default.svc:5000/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
+
+

--- a/roles/ocp-25021-cronjob/tasks/main.yml
+++ b/roles/ocp-25021-cronjob/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Get oc version
+  include_role:
+    name: migration_getfacts
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate migration
+  import_tasks: validate.yml
+  when: with_validate|bool

--- a/roles/ocp-25021-cronjob/tasks/migrate.yml
+++ b/roles/ocp-25021-cronjob/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-25021-cronjob/tasks/track.yml
+++ b/roles/ocp-25021-cronjob/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-25021-cronjob/tasks/validate.yml
+++ b/roles/ocp-25021-cronjob/tasks/validate.yml
@@ -1,0 +1,32 @@
+- name: Check image stream
+  k8s_facts:
+    kind: ImageStream
+    namespace: "{{ namespace }}"
+    name: "{{ internal_image_name }}"
+  register: imagestream
+  until: (imagestream.resources | length == 1) and (imagestream.resources[0].status.dockerImageRepository is search(internal_image_name | string))
+  retries: 30
+
+- name: Check external image nodes status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "cronowner={{ ext_app_name }}"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Check internal image nodes status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "cronowner={{ int_app_name }}"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+#TODO: when possible, check that original cronjobs have not been quiesced.

--- a/roles/ocp-25021-cronjob/templates/deployment.yml.j2
+++ b/roles/ocp-25021-cronjob/templates/deployment.yml.j2
@@ -1,0 +1,35 @@
+apiVersion: v1
+items:
+- apiVersion: {{ cronjob_api }}
+  kind: CronJob
+  metadata:
+    labels:
+      app: '{{ app_name }}'
+    name: '{{ app_name }}'
+  spec:
+    jobTemplate:
+      metadata:
+        labels:
+          cronowner: '{{ app_name }}'
+      spec:
+        template:
+          metadata:
+            labels:
+              cronowner: '{{ app_name }}'
+          spec:
+            containers:
+            - args:
+              - /bin/sh
+              - -c
+              - echo "Hello! from namespace $CURRENT_NAMESPACE while using image {{ docker_image }}"
+              env:
+              - name: CURRENT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              image: '{{ docker_image }}'
+              name: '{{ app_name }}'
+            restartPolicy: OnFailure
+    schedule: '*/1 * * * *'
+kind: List
+metadata: {}

--- a/roles/ocp-25090-jobs/defaults/main.yml
+++ b/roles/ocp-25090-jobs/defaults/main.yml
@@ -1,0 +1,20 @@
+namespace: ocp-25090-jobs
+
+int_app_name: internal-job
+ext_app_name: external-job
+fast_app_name: fast-job
+
+internal_image_name: internal-alpine
+internal_image_tag: int
+external_image_name: docker.io/alpine
+
+migration_sample_name: ocp-25090-jobs
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: true

--- a/roles/ocp-25090-jobs/tasks/deploy.yml
+++ b/roles/ocp-25090-jobs/tasks/deploy.yml
@@ -1,0 +1,44 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }}  --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Import image to imagestream
+  shell: "{{ oc_binary }} -n {{ namespace }}  import-image {{ internal_image_name }}:{{ internal_image_tag }} --from {{ external_image_name }} --confirm"
+
+- name: Deploy job using external image
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    app_name: "{{ ext_app_name }}"
+    sleep_time: 1d
+    docker_image: docker.io/alpine
+
+
+- name: Deploy job using internal image
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    app_name: "{{ int_app_name }}"
+    sleep_time: 1d
+    docker_image: "docker-registry.default.svc:5000/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
+
+
+- name: Deploy fast job using external image. This fob will end and should not be migrated
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    app_name: "{{ fast_app_name }}"
+    sleep_time: 1
+    docker_image: docker.io/alpine

--- a/roles/ocp-25090-jobs/tasks/main.yml
+++ b/roles/ocp-25090-jobs/tasks/main.yml
@@ -1,0 +1,25 @@
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate-source.yml
+  when: (with_validate|bool) and (with_deploy|bool)
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)

--- a/roles/ocp-25090-jobs/tasks/migrate.yml
+++ b/roles/ocp-25090-jobs/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-25090-jobs/tasks/track.yml
+++ b/roles/ocp-25090-jobs/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-25090-jobs/tasks/validate-source.yml
+++ b/roles/ocp-25090-jobs/tasks/validate-source.yml
@@ -1,0 +1,68 @@
+- name: Check image stream
+  k8s_facts:
+    kind: ImageStream
+    namespace: "{{ namespace }}"
+    name: "{{ internal_image_name }}"
+  register: imagestream
+  until: (imagestream.resources | length == 1) and (imagestream.resources[0].status.dockerImageRepository is search(internal_image_name | string))
+  retries: 10
+
+- name: Check external image job status. Must be active.
+  k8s_facts:
+    kind: Job
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ ext_app_name }}"
+  register: job
+  until: job.resources | length > 0 and job.resources[0].status.active == 1
+  retries: 30
+
+- name: Check internal image job status. Must be active.
+  k8s_facts:
+    kind: Job
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ int_app_name }}"
+  register: job
+  until: job.resources | length > 0 and job.resources[0].status.active == 1
+  retries: 30
+
+- name: Check fast job status. Must be finished.
+  k8s_facts:
+    kind: Job
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ fast_app_name }}"
+  register: job
+  until: job.resources | length > 0 and job.resources[0].status.succeeded is defined and job.resources[0].status.succeeded == 1
+  retries: 30
+
+- name: Check external image nodes status. Must be running.
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ ext_app_name }}"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Check internal image nodes status. Must be running.
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ int_app_name }}"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Check fast nodes status. Must be completed and succeed.
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ fast_app_name }}"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30

--- a/roles/ocp-25090-jobs/tasks/validate-target.yml
+++ b/roles/ocp-25090-jobs/tasks/validate-target.yml
@@ -1,0 +1,73 @@
+- name: Check image stream
+  k8s_facts:
+    kind: ImageStream
+    namespace: "{{ namespace }}"
+    name: "{{ internal_image_name }}"
+  register: imagestream
+  until: (imagestream.resources | length == 1) and (imagestream.resources[0].status.dockerImageRepository is search(internal_image_name | string))
+  retries: 10
+
+- name: Check external image job status. Must be active.
+  k8s_facts:
+    kind: Job
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ ext_app_name }}"
+  register: job
+  until: job.resources | length > 0 and job.resources[0].status.active == 1
+  retries: 30
+
+- name: Check internal image job status. Must be active.
+  k8s_facts:
+    kind: Job
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ int_app_name }}"
+  register: job
+  until: job.resources | length > 0 and job.resources[0].status.active == 1
+  retries: 30
+
+- name: Check fast job status. Must not be present.
+  k8s_facts:
+    kind: Job
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ fast_app_name }}"
+  register: job
+
+- fail:
+    msg: Fast job should not be migrated
+  when: job.resources | length > 0
+
+- name: Check external image nodes status. Must be running.
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ ext_app_name }}"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Check internal image nodes status. Must be running.
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ int_app_name }}"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Check fast nodes status. Must not be present.
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ fast_app_name }}"
+  register: pod
+
+- fail: 
+    msg: Fast node should not be migrated
+  when: pod.resources | length > 0
+
+
+#TODO: when possible, check that original jobs have been quiesced.

--- a/roles/ocp-25090-jobs/templates/deployment.yml.j2
+++ b/roles/ocp-25090-jobs/templates/deployment.yml.j2
@@ -1,0 +1,27 @@
+apiVersion: v1
+items:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    labels:
+      app: '{{ app_name }}'
+    name: '{{ app_name }}'
+  spec:
+    template:
+      metadata:
+        labels:
+          app: '{{ app_name }}'
+      spec:
+        containers:
+        - command:
+          - sh
+          - -c
+          - |-
+            echo 'Original source image: {{ docker_image }} Sleeping for {{ sleep_time }}';
+            sleep {{ sleep_time }};
+            echo 'Done!'
+          image: '{{ docker_image }}'
+          name: '{{ app_name }}'
+        restartPolicy: Never
+kind: List
+metadata: {}

--- a/roles/ocp-25212-initcont/defaults/main.yml
+++ b/roles/ocp-25212-initcont/defaults/main.yml
@@ -1,0 +1,20 @@
+namespace: ocp-25212-initcont
+replicas: 1
+
+int_app_name: internal-nginx
+ext_app_name: external-nginx
+
+external_image_name: docker.io/alpine
+internal_image_name: internal-alpine
+internal_image_tag: int
+
+migration_sample_name: ocp-25212-initcont
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: true

--- a/roles/ocp-25212-initcont/tasks/deploy.yml
+++ b/roles/ocp-25212-initcont/tasks/deploy.yml
@@ -1,0 +1,34 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Import image to imagestream
+  shell: "{{ oc_binary }} -n {{ namespace }}  import-image {{ internal_image_name }}:{{ internal_image_tag }} --from {{ external_image_name }} --confirm"
+
+- name: Deploy pods using external image
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    replicas: 1
+    app_name: "{{ ext_app_name }}"
+    init_image: docker.io/alpine
+
+
+- name: Deploy pods using internal image
+  k8s:
+    state : present
+    namespace : "{{ namespace }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    replicas: 1
+    app_name: "{{ int_app_name }}"
+    init_image: "docker-registry.default.svc:5000/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
+

--- a/roles/ocp-25212-initcont/tasks/main.yml
+++ b/roles/ocp-25212-initcont/tasks/main.yml
@@ -1,0 +1,21 @@
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate migration
+  import_tasks: validate.yml
+  when: with_validate|bool

--- a/roles/ocp-25212-initcont/tasks/migrate.yml
+++ b/roles/ocp-25212-initcont/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-25212-initcont/tasks/track.yml
+++ b/roles/ocp-25212-initcont/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-25212-initcont/tasks/validate.yml
+++ b/roles/ocp-25212-initcont/tasks/validate.yml
@@ -1,0 +1,55 @@
+- name: Check external image nodes status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ ext_app_name}}"
+  register: pod
+  #until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+  until: pod | json_query('resources[*].status.containerStatuses[*].ready') | flatten |difference( [true] ) | length  == 0
+  retries: 30
+
+- name: Check internal image nodes status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ int_app_name }}"
+  register: pod
+  #until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+  until: pod | json_query('resources[*].status.containerStatuses[*].ready') | flatten |difference( [true] ) | length  == 0
+  retries: 30
+
+- name: Obtain  internal route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ int_app_name }}"
+  register: int_route
+  retries: 10
+  until: int_route.resources | length > 0
+
+- name: Obtain  external route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "app={{ ext_app_name}}"
+  register: ext_route
+  retries: 10
+  until: ext_route.resources | length > 0
+
+- name: Acces the internal route content
+  uri:
+    url: http://{{ int_route.resources[0].spec.host }}
+    method: GET
+    return_content: yes
+  register: this
+  retries: 10
+  until: "'<h1>HELLO WORLD</h1>' in this.content"
+
+- name: Acces the external route content
+  uri:
+    url: http://{{ ext_route.resources[0].spec.host }}
+    method: GET
+    return_content: yes
+  register: this
+  retries: 10
+  until: "'<h1>HELLO WORLD</h1>' in this.content"

--- a/roles/ocp-25212-initcont/templates/deployment.yml.j2
+++ b/roles/ocp-25212-initcont/templates/deployment.yml.j2
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: {{ app_name }}-deployment
+    labels:
+      app: {{ app_name }}
+  spec:
+    replicas: {{ replicas }}
+    selector:
+      matchLabels:
+        app: {{ app_name }}
+    template:
+      metadata:
+        labels:
+          app: {{ app_name }}
+      spec:
+        volumes:
+        - name: html-volume
+          emptyDir: {}
+        containers:
+        - name: {{ app_name }}
+          image: docker.io/twalter/openshift-nginx
+          ports:
+          - containerPort: 8081
+          volumeMounts:
+            - mountPath: "/usr/share/nginx/html"
+              name: html-volume
+        initContainers:
+        - name: provision-pod
+          image: {{ init_image }}
+          command: ['/bin/sh']
+          args: ['-c', "echo '<h1>HELLO WORLD</h1>' > /usr/share/nginx/html/index.html"]
+          volumeMounts:
+            - mountPath: "/usr/share/nginx/html"
+              name: html-volume
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: {{ app_name }}
+    name: {{ app_name }}-service
+  spec:
+    ports:
+    - port: 8081
+      targetPort: 8081
+    selector:
+      app: {{ app_name }}
+    type: LoadBalancer
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: {{ app_name }}-route
+    labels:
+      app: {{ app_name }}
+      service: {{ app_name }}-service
+  spec:
+    to:
+      kind: Service
+      name: {{ app_name }}-service
+    port:
+      targetPort: 8081
+  


### PR DESCRIPTION
Add tests 
- ocp-25000: basic statefulset, daemonset, replicaset test
Creates one statefulset, one daemonset and one replicaset and migrates them.

- ocp-25021: basic init containers test
Creates two pods with an nginx container with empty html directory and an init-container that writes a "hello-world" html file in it.
One pod is using an init-container with external image, and the other one with internal image.


- ocp-25090: basic job test
Creates 2 jobs that remain waiting without ending or doing anything. One using an internal image and the other one using an external image. They both will be running during the migration.
Creates 1 job that will end before migration
Only running jobs should be migrated.


- ocp-25212: basic cronjob test
Creates 2 cronjobs saying "hello-world". One using an external image and the other one using an internal image.

- ocp-24997: basic confimap configuration test
Creates a redis and uses a configmap to configure the memory of this redis instance. After checking that the migration is OK, checks that the redis configuration in the target cluster matches the one defined in the configmap.