### PR TITLE
Optional migclusters and migstorage creation

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,4 +1,8 @@
 # default common variables for mig-e2e roles/plays
 
 migration_namespace: openshift-migration
+migcluster_source_name: migcluster-remote-mod
+migcluster_target_name: migcluster-local-mod
+migstorage_name: migstorage-sample-mod
+
 oc_binary: "oc"

--- a/roles/migration_prepare/tasks/main.yml
+++ b/roles/migration_prepare/tasks/main.yml
@@ -7,3 +7,4 @@
 - name: Prepare clusters for migration
   import_tasks: prepare_clusters.yml
   when: with_migrate|bool
+  tags: ["always", "prepare_cluster"]

--- a/roles/migration_prepare/templates/mig-cluster-local.yml.j2
+++ b/roles/migration_prepare/templates/mig-cluster-local.yml.j2
@@ -3,7 +3,7 @@ kind: MigCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migcluster-local
+  name: {{ migcluster_target_name }}
   namespace: {{ migration_namespace }}
 spec:
   # [!] Change isHostCluster to 'false' if you want to use a clusterRef and serviceAccountSecretRef

--- a/roles/migration_prepare/templates/mig-cluster-remote.yml.j2
+++ b/roles/migration_prepare/templates/mig-cluster-remote.yml.j2
@@ -3,7 +3,7 @@ kind: MigCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migcluster-remote
+  name: {{ migcluster_source_name }}
   namespace: {{ migration_namespace }}
 spec:
   # [!] Change isHostCluster to 'true' if you'll be running the controller on this cluster.
@@ -11,7 +11,7 @@ spec:
   isHostCluster: false
 
   serviceAccountSecretRef:
-    name: sa-token-remote
+    name: sa-token-{{ migcluster_source_name }}
     namespace: {{ migration_namespace }}
 
   url: {{ mig_controller_remote_cluster_url }}

--- a/roles/migration_prepare/templates/mig-storage-creds.yml.j2
+++ b/roles/migration_prepare/templates/mig-storage-creds.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ migration_namespace }}
-  name: migstorage-creds
+  name: {{ migstorage_name }}-creds
 type: Opaque
 data:
   # [!] If using S3 / AWS, change aws-access-key-id and aws-secret-access-key to contain the base64 encoded keys

--- a/roles/migration_prepare/templates/mig-storage.yml.j2
+++ b/roles/migration_prepare/templates/mig-storage.yml.j2
@@ -3,7 +3,7 @@ kind: MigStorage
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migstorage-sample
+  name: {{ migstorage_name }}
   namespace: {{ migration_namespace }}
 spec:
   backupStorageProvider: aws
@@ -16,7 +16,7 @@ spec:
     awsRegion: {{ mig_controller_aws_bucket_region }}
     credsSecretRef:
       namespace: {{ migration_namespace }}
-      name: migstorage-creds
+      name: {{ migstorage_name }}-creds
 
     # Optional backupStorageConfig parameters
     #awsKmsKeyId: foo
@@ -28,5 +28,5 @@ spec:
     awsRegion: {{ mig_controller_aws_bucket_region }}
     credsSecretRef:
       namespace: {{ migration_namespace }}
-      name: migstorage-creds
+      name: {{ migstorage_name }}-creds
 

--- a/roles/migration_prepare/templates/sa-secret-remote.yml.j2
+++ b/roles/migration_prepare/templates/sa-secret-remote.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: sa-token-remote
+  name: sa-token-{{ migcluster_source_name }}
   namespace: {{ migration_namespace }}
 type: Opaque
 data:

--- a/roles/migration_run/templates/mig-plan-pv.yml.j2
+++ b/roles/migration_run/templates/mig-plan-pv.yml.j2
@@ -8,15 +8,15 @@ metadata:
 spec:
 
   srcMigClusterRef:
-    name: migcluster-remote
+    name: {{ migcluster_source_name }}
     namespace: {{ migration_namespace }}
 
   destMigClusterRef:
-    name: migcluster-local
+    name: {{ migcluster_target_name }}
     namespace: {{ migration_namespace }}
 
   migStorageRef:
-    name: migstorage-sample
+    name: {{ migstorage_name }}
     namespace: {{ migration_namespace }}
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster

--- a/roles/migration_run/templates/mig-plan.yml.j2
+++ b/roles/migration_run/templates/mig-plan.yml.j2
@@ -8,15 +8,15 @@ metadata:
 spec:
 
   srcMigClusterRef:
-    name: migcluster-remote
+    name: {{ migcluster_source_name }}
     namespace: {{ migration_namespace }}
 
   destMigClusterRef:
-    name: migcluster-local
+    name: {{ migcluster_target_name }}
     namespace: {{ migration_namespace }}
 
   migStorageRef:
-    name: migstorage-sample
+    name: {{ migstorage_name }}
     namespace: {{ migration_namespace }}
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster


### PR DESCRIPTION
Now the cluster preparation is mandatory, and the names of the migclusters and migstorage are fixed.

With this PR those names are configurable via config/default.yml file or ansible parameters, and the cluster preparation (migcluster and migstorage creation) is optional. This way we can run the test against any App Migration with any migclusters and any migstorage configured in it.

In order to skip the cluster preparation add the parameter "--skip-tags prepare_cluster" to the ansible-playbook command.

Probably it makes more sense to do it the other way around, not to run prepare_cluster by default. But this way we don't impact the jenkins current configuration. In the near future we can change it if we want to.