### PR TITLE
Add basic support for more than one namespace

### DIFF
--- a/roles/migration_cleanup/tasks/remove_namespace.yml
+++ b/roles/migration_cleanup/tasks/remove_namespace.yml
@@ -1,8 +1,9 @@
 - name: Ensure namespace {{ namespace }} is absent before continuing...
   k8s:
-    name: "{{ namespace }}"
+    name: "{{ item }}"
     api_version: v1
     kind: Namespace
     state: absent
     wait: yes
     wait_timeout: 300
+  loop: "{{ [namespace] if namespace is string else namespace }}"

--- a/roles/migration_run/tasks/main.yml
+++ b/roles/migration_run/tasks/main.yml
@@ -1,3 +1,7 @@
+- fail:
+    msg: "Proccess persistent volumes (pv: true) can only handle one namespace. Current namespaces {{ namespace }}"
+  when: (pv|default(false)|bool == true) and (not namespace is string and namespace | length > 1)
+
 - name: Include required vars
   include_vars:
     file: "{{ playbook_dir }}/config/mig_controller.yml"

--- a/roles/migration_run/templates/mig-plan-pv.yml.j2
+++ b/roles/migration_run/templates/mig-plan-pv.yml.j2
@@ -20,8 +20,11 @@ spec:
     namespace: {{ migration_namespace }}
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster
-  namespaces: 
-  - {{ namespace }}
+{% if namespace is string %}
+  namespaces: [ {{ namespace }} ]
+{% else %}
+  namespaces: {{ namespace | to_yaml }}
+{% endif %}
 
 {% if pv is sameas true and pv_list is defined %}
   persistentVolumes:

--- a/roles/migration_run/templates/mig-plan.yml.j2
+++ b/roles/migration_run/templates/mig-plan.yml.j2
@@ -20,5 +20,8 @@ spec:
     namespace: {{ migration_namespace }}
 
   # [!] Change namespaces to adjust which OpenShift namespaces should be migrated from source to destination cluster
-  namespaces: 
-  - {{ namespace }}
+{% if namespace is string %}
+  namespaces: [ {{ namespace }} ]
+{% else %}
+  namespaces: {{ namespace | to_yaml }}
+{% endif %}


### PR DESCRIPTION
Add basic support so that test cases can handle more than one namespace.

Using more than one namespace and setting "pv: true" will result in an error, since this is not already supported. Only cases with "pv: false" will be able to use more than one namespace.