### PR TITLE
Fix k8s_info error

### DIFF
--- a/roles/migration_run/tasks/main.yml
+++ b/roles/migration_run/tasks/main.yml
@@ -24,7 +24,7 @@
     mig_velero_pause: true
 
 - name: Get plan information when ready
-  k8s_info:
+  k8s_facts:
     kind: MigPlan
     api_version: v1alpha1
     namespace: "{{ migration_namespace }}"


### PR DESCRIPTION
It seems that ansible's version in CI is old, hence it doesn't have k8s_info task.

This PR changes  the k8s_info task to its older version k8s_facts task. It should fix the following error in CI

```
changed: [localhost]
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to be in '/var/lib/jenkins/workspace/ci-mig-e2e-base@3-1480/mig-e2e/roles/migration_run/tasks/main.yml': line 26, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Get plan information when ready
  ^ here

```