### PR TITLE
Add ocp-26160-max-pvs testcase

### DIFF
--- a/e2e_mig_samples.yml
+++ b/e2e_mig_samples.yml
@@ -20,6 +20,7 @@
     # 3.7 -> 4.x migration failing for django because 9.5 postgres image does not exist in 4.x
     - { role: ocp-24730-django, tags: ["never", "ocp-24730-django"] }
     - { role: ocp-26032-maxns, tags: ["ocp-26032-maxns", "ocp"] }
+    - { role: ocp-26160-max-pvs, tags: ["ocp-26160-max-pvs", "ocp"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/nginx-pv/tasks/deploy.yml
+++ b/roles/nginx-pv/tasks/deploy.yml
@@ -41,6 +41,8 @@
     url: http://{{ nginx_route.resources[0].spec.host }}
     method: GET
     status_code: 403
+  register: uri_output
+  until: uri_output.status != 503
 
 - name: Upload an index html file
   shell: "{{ oc_binary }} -n {{ namespace }} rsh $( {{oc_binary}} get pods -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}') sh -c 'echo \"<h1>HELLO WORLD</h1>\" > /usr/share/nginx/html/index.html'"

--- a/roles/nginx-pv/tasks/main.yml
+++ b/roles/nginx-pv/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Validate default storageclasses
   import_tasks: common_tasks/validate-defaults.yml
-  when: (with_validate|bool) and (with_migrate|bool)
+  when: ((with_validate|bool) and (with_migrate|bool)) or (with_validate_source|default(false)|bool)
 
 - name: Track migration
   import_tasks: track.yml
@@ -25,11 +25,11 @@
 
 - name: Validate source
   import_tasks: validate-source.yml
-  when: (with_validate|bool) and (with_deploy|bool)
+  when: ((with_validate|bool) and (with_deploy|bool)) or (with_validate_source|default(false)|bool)
 
 - name: Validate migration
   import_tasks: validate-target.yml
-  when: (with_validate|bool) and (with_migrate|bool)
+  when: ((with_validate|bool) and (with_migrate|bool)) or (with_validate_target|default(false)|bool)
 
 - name: Restore ceph storage classes
   import_tasks: restore_ceph.yml

--- a/roles/ocp-26160-max-pvs/defaults/main.yml
+++ b/roles/ocp-26160-max-pvs/defaults/main.yml
@@ -1,0 +1,21 @@
+num_namespaces: 3
+# In every namespace we will deploy this role.
+# The nginx-pv role uses 2 pvs,
+# hence, 3 namespaces will imply 6 PVs to migrate. 2 pvs each.
+deployed_role: nginx-pv
+pv_limit: 5
+
+
+#default_replicas: 1
+#default_app_name: nginx
+
+migration_sample_name: "max-pvs"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+mpv_with_deploy: true
+mpv_with_migrate: true
+mpv_with_cleanup: true
+mpv_with_validate: true
+pv: false
+quiesce: false

--- a/roles/ocp-26160-max-pvs/tasks/main.yml
+++ b/roles/ocp-26160-max-pvs/tasks/main.yml
@@ -1,0 +1,54 @@
+- name: Generate namespaces
+  set_fact:
+    all_namespaces: "{{ all_namespaces|default([]) + ['max-pvs-' + item|string]}}"
+  with_sequence: "1-{{ num_namespaces }}" 
+  loop_control:
+    label: "{{ 'Generated namespace name: max-pvs-' + item|string }}"
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  vars:
+    namespace: "{{ all_namespaces|default([]) }}"
+  when: with_cleanup|bool
+
+- name: Deploy application in namespaces
+  include_role:
+    name: "{{ deployed_role }}"
+  vars:
+    namespace: "{{ namespace_item }}"
+    with_migrate: false
+  loop: "{{ all_namespaces }}"
+  loop_control:
+    loop_var: namespace_item
+  when: (with_validate|bool) and (with_deploy|bool)
+
+
+- name: Start migration
+  import_tasks: migrate.yml
+  vars:
+    namespace: "{{ all_namespaces }}"
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)
+
+
+- name: Validate application in namespaces
+  include_role:
+    name: "{{ deployed_role }}"
+  vars:
+    namespace: "{{ namespace_item }}"
+    with_migrate: false
+    with_cleanup: false
+    with_validate_target: true
+  loop: "{{ all_namespaces }}"
+  loop_control:
+    loop_var: namespace_item
+  # This variables seem to collide with the ones in the "vars" section. We need to be careful, and negate "deploy" instead of using "migrate"
+  when: (with_validate|bool) and not (with_deploy|bool)

--- a/roles/ocp-26160-max-pvs/tasks/migrate.yml
+++ b/roles/ocp-26160-max-pvs/tasks/migrate.yml
@@ -1,0 +1,31 @@
+- name: Get mig controller information
+  k8s_facts:
+    api_version: migration.openshift.io/v1alpha1
+    kind: MigrationController
+    name: migration-controller
+    namespace: "{{ migration_namespace }}"
+  register: mig_controller
+  until: mig_controller.resources | length > 0
+
+- name: Store controller config, removing the resource version
+  set_fact:
+    previous_controller: >-
+                         {{ (mig_controller.resources|first)|
+                          combine({'metadata':{ 
+                                                'name': (mig_controller.resources|first).metadata.name, 
+                                                'namespace': (mig_controller.resources|first).metadata.namespace } }) }}
+
+- name: Update mig controller
+  k8s:
+    api_version: migration.openshift.io/v1alpha1
+    namespace: "{{ migration_namespace }}"
+    definition: "{{ previous_controller | combine({ 'spec': {'mig_pv_limit': pv_limit|string } }) }}"
+
+- pause:
+    prompt: Wait 1 minute for controller reconciliation
+    minutes: 1
+
+- name: Execute migration
+  include_role:
+    name: migration_run
+

--- a/roles/ocp-26160-max-pvs/tasks/track.yml
+++ b/roles/ocp-26160-max-pvs/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-26160-max-pvs/tasks/validate-target.yml
+++ b/roles/ocp-26160-max-pvs/tasks/validate-target.yml
@@ -1,0 +1,27 @@
+- name: Check if migration plan has a PV limit exceeded warning
+  fail:
+    msg: "Migration plan should have a PvLimitExceeded warning, but this warning is not present"
+  when: fact_migrated_plan.status.get('conditions', {}) | list | selectattr( "type", "equalto", "PvLimitExceeded") | selectattr( "category", "equalto", "Warn") | list | length == 0
+
+- name: PV limit exceeded warning found
+  debug: 
+    msg: "{{ fact_migrated_plan.status.get('conditions', {}) | list | selectattr( 'type', 'equalto', 'PvLimitExceeded') | selectattr( 'category', 'equalto', 'Warn') | list }}"
+
+- name: All namespaces
+  debug:
+    msg: "{{ all_namespaces }}"
+
+- name: Get mig controller information to restore the original limit
+  k8s_facts:
+    api_version: migration.openshift.io/v1alpha1
+    kind: MigrationController
+    name: migration-controller
+    namespace: "{{ migration_namespace }}"
+  register: mig_controller
+  until: mig_controller.resources | length > 0
+
+- name: Restore mig controller initial limit values
+  k8s:
+    api_version: migration.openshift.io/v1alpha1
+    namespace: "{{ migration_namespace }}"
+    definition: "{{ previous_controller }}"


### PR DESCRIPTION
Add ocp-26160 testcase to verify that `mig_pv_limit` configured value is honored.

1) Generate 3 namespaces
2) Deploy a nginx role (with 2 PVS each, a total of 6 PVs deployed) in each of those namespaces
3) Configure a limit of 5 PVs in the cluster.
4) Migrate
5) Validate that the warning is there
6) Verify that every namespace was migrated properly with no failures (the warning does not block the migration, the migration should be executed without failures)