### PR TITLE
Make limit tests more stable

### DIFF
--- a/roles/ocp-25986-maxpods/tasks/migrate.yml
+++ b/roles/ocp-25986-maxpods/tasks/migrate.yml
@@ -7,15 +7,19 @@
   register: mig_controller
   until: mig_controller.resources | length > 0
 
-- name: Store controller config
+- name: Store controller config, removing the resource version
   set_fact:
-    previous_pod_limit: "{{ (mig_controller.resources|first).spec.get('mig_pod_limit', 100) }}"
+    previous_controller: >-
+                         {{ (mig_controller.resources|first)|
+                          combine({'metadata':{
+                                                'name': (mig_controller.resources|first).metadata.name,
+                                                'namespace': (mig_controller.resources|first).metadata.namespace } }) }}
 
-- name: Update mig controller
+- name: Update mig controller with the new pod limit
   k8s:
     api_version: migration.openshift.io/v1alpha1
     namespace: "{{ migration_namespace }}"
-    definition: "{{ (mig_controller.resources|first) | combine({ 'spec': {'mig_pod_limit': pod_limit } }) }}"
+    definition: "{{ previous_controller | combine({ 'spec': {'mig_pod_limit': pod_limit|string } }) }}"
 
 - pause:
     prompt: Wait 1 minute for controller reconciliation

--- a/roles/ocp-25986-maxpods/tasks/validate-target.yml
+++ b/roles/ocp-25986-maxpods/tasks/validate-target.yml
@@ -12,18 +12,8 @@
   debug: 
     msg: "{{ mig_plan.resources[0].status.get('conditions', {}) | list | selectattr( 'type', 'equalto', 'PodLimitExceeded') | selectattr( 'category', 'equalto', 'Warn') | list }}"
 
-
-- name: Get mig controller information to restore the original limit
-  k8s_facts:
-    api_version: migration.openshift.io/v1alpha1
-    kind: MigrationController
-    name: migration-controller
-    namespace: "{{ migration_namespace }}"
-  register: mig_controller
-  until: mig_controller.resources | length > 0
-
 - name: Restore mig controller initial limit values
   k8s:
     api_version: migration.openshift.io/v1alpha1
     namespace: "{{ migration_namespace }}"
-    definition: "{{ (mig_controller.resources|first) | combine({ 'spec': {'mig_pod_limit': previous_pod_limit|int } }) }}"
+    definition: "{{ previous_controller }}"

--- a/roles/ocp-26032-maxns/tasks/migrate.yml
+++ b/roles/ocp-26032-maxns/tasks/migrate.yml
@@ -7,15 +7,18 @@
   register: mig_controller
   until: mig_controller.resources | length > 0
 
-- name: Store controller config
+- name: Store controller config, removing the resource version
   set_fact:
-    previous_namespace_limit: "{{ (mig_controller.resources|first).spec.get('mig_namespace_limit', 100) }}"
-
+    previous_controller: >-
+                         {{ (mig_controller.resources|first)|
+                          combine({'metadata':{
+                                                'name': (mig_controller.resources|first).metadata.name,
+                                                'namespace': (mig_controller.resources|first).metadata.namespace } }) }}
 - name: Update mig controller
   k8s:
     api_version: migration.openshift.io/v1alpha1
     namespace: "{{ migration_namespace }}"
-    definition: "{{ (mig_controller.resources|first) | combine({ 'spec': {'mig_namespace_limit': namespace_limit } }) }}"
+    definition: "{{ previous_controller | combine({ 'spec': {'mig_namespace_limit': namespace_limit|string } }) }}"
 
 - pause:
     prompt: Wait 1 minute for controller reconciliation

--- a/roles/ocp-26032-maxns/tasks/validate-target.yml
+++ b/roles/ocp-26032-maxns/tasks/validate-target.yml
@@ -12,18 +12,8 @@
   debug: 
     msg: "{{ mig_plan.resources[0].status.get('conditions', {}) | list | selectattr( 'type', 'equalto', 'NamespaceLimitExceeded') | selectattr( 'category', 'equalto', 'Critical') | list }}"
 
-
-- name: Get mig controller information to restore the original limit
-  k8s_facts:
-    api_version: migration.openshift.io/v1alpha1
-    kind: MigrationController
-    name: migration-controller
-    namespace: "{{ migration_namespace }}"
-  register: mig_controller
-  until: mig_controller.resources | length > 0
-
 - name: Restore mig controller initial limit values
   k8s:
     api_version: migration.openshift.io/v1alpha1
     namespace: "{{ migration_namespace }}"
-    definition: "{{ (mig_controller.resources|first) | combine({ 'spec': {'mig_namespace_limit': previous_namespace_limit|int } }) }}"
+    definition: "{{ previous_controller }}"


### PR DESCRIPTION
Sometimes limit testcases fail because the changes in migration controller object have conflicts because of the resource version.

This PR fixes this problem, and makes those cases more stable.