### PR TITLE
Clean all namespaces when a list is given to the clean up task

### DIFF
--- a/roles/migration_cleanup/tasks/remove_namespace.yml
+++ b/roles/migration_cleanup/tasks/remove_namespace.yml
@@ -1,8 +1,9 @@
 - name: Ensure namespace {{ namespace }} is absent before continuing...
   k8s:
-    name: "{{ namespace }}"
+    name: "{{ item }}"
     api_version: v1
     kind: Namespace
     state: absent
     wait: yes
     wait_timeout: 300
+  loop: "{{ [namespace] if namespace is string else namespace }}"


### PR DESCRIPTION
When support for several namespaces was added, we forgot to modify the clean up logic.

This PR fixes this problem, and makes sure that all namespaces are deleted when a list is passed to the clean up task.