### PR TITLE
Remove the execution triggered and blocked in max-ns testcase

### DIFF
--- a/roles/ocp-26032-maxns/tasks/validate-target.yml
+++ b/roles/ocp-26032-maxns/tasks/validate-target.yml
@@ -12,6 +12,14 @@
   debug: 
     msg: "{{ mig_plan.resources[0].status.get('conditions', {}) | list | selectattr( 'type', 'equalto', 'NamespaceLimitExceeded') | selectattr( 'category', 'equalto', 'Critical') | list }}"
 
+- name: Remove the blocked execution
+  k8s:
+    api_version: migration.openshift.io/v1alpha1
+    state: absent
+    kind: MigMigration
+    name: "{{ migration_name }}"
+    namespace: "{{ migration_namespace }}"
+
 - name: Restore mig controller initial limit values
   k8s:
     api_version: migration.openshift.io/v1alpha1


### PR DESCRIPTION
A build is triggered and blocked with a critical condition in max-ns testcase.

Once the limit is restored to its original value, this build stops being blocked, and is immediately executed. Thus, the next testcase is running with this run in the background, and can fail because of a timeout.

This PR deletes the blocked execution before restoring the original namespaces limit.