### PR TITLE
Add wait for warnings before running the plan

### DIFF
--- a/roles/migration_run/defaults/main.yml
+++ b/roles/migration_run/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 mig_velero_timeout: 10
+# If true, we will wait for a warning to be displayed before running the migration plan.
+wait_for_warnings: false

--- a/roles/migration_run/tasks/main.yml
+++ b/roles/migration_run/tasks/main.yml
@@ -23,6 +23,18 @@
 - set_fact:
     mig_velero_pause: true
 
+- name: Warnings must be present. Waiting for warnings.
+  k8s_facts:
+    kind: MigPlan
+    api_version: v1alpha1
+    namespace: "{{ migration_namespace }}"
+    name: "{{ migration_plan_name }}"
+  register: mig_plan
+  until: mig_plan.resources|length > 0 and (mig_plan.resources[0].get( 'status', {}).get("conditions", {}) | selectattr( 'category', 'match', 'Warn|Critical') | list | length > 0)
+  retries: 30
+  delay: 5
+  when: wait_for_warnings|bool
+
 - name: Get plan information when ready
   k8s_facts:
     kind: MigPlan

--- a/roles/ocp-25986-maxpods/tasks/migrate.yml
+++ b/roles/ocp-25986-maxpods/tasks/migrate.yml
@@ -21,10 +21,9 @@
     namespace: "{{ migration_namespace }}"
     definition: "{{ previous_controller | combine({ 'spec': {'mig_pod_limit': pod_limit|string } }) }}"
 
-- pause:
-    prompt: Wait 1 minute for controller reconciliation
-    minutes: 1
 
 - name: Execute migration
   include_role:
     name: migration_run
+  vars:
+    wait_for_warnings: true

--- a/roles/ocp-26032-maxns/tasks/migrate.yml
+++ b/roles/ocp-26032-maxns/tasks/migrate.yml
@@ -20,11 +20,9 @@
     namespace: "{{ migration_namespace }}"
     definition: "{{ previous_controller | combine({ 'spec': {'mig_namespace_limit': namespace_limit|string } }) }}"
 
-- pause:
-    prompt: Wait 1 minute for controller reconciliation
-    minutes: 1
-
 - name: Execute migration
   include_role:
     name: migration_run
+  vars:
+    wait_for_warnings: true
 

--- a/roles/ocp-26160-max-pvs/tasks/migrate.yml
+++ b/roles/ocp-26160-max-pvs/tasks/migrate.yml
@@ -21,11 +21,10 @@
     namespace: "{{ migration_namespace }}"
     definition: "{{ previous_controller | combine({ 'spec': {'mig_pv_limit': pv_limit|string } }) }}"
 
-- pause:
-    prompt: Wait 1 minute for controller reconciliation
-    minutes: 1
 
 - name: Execute migration
   include_role:
     name: migration_run
+  vars:
+    wait_for_warnings: true
 


### PR DESCRIPTION
Add an option to wait for warnings to be displayed before running the migration plan.

wait_for_warnings: true
The migration_run role will not run the migration plan until a warning (or Critical condition) is displayed. If no warning is displayed, it fails. By default the value is false.