### PR TITLE
Adapt default registry testcases to 4x source clusters

### DIFF
--- a/roles/migration_getfacts/tasks/main.yml
+++ b/roles/migration_getfacts/tasks/main.yml
@@ -17,6 +17,10 @@
       msg: "Ocp is not a 4.x cluster"
     when: cv.resources | length == 0
 
+  - name: Set 4.x default registry
+    set_fact:
+      default_registry: "image-registry.openshift-image-registry.svc:5000"
+
   rescue:
   - name: Cluster is not 4.x. Checking for 3.x version.
     shell: "{{ oc_binary }} version"
@@ -24,6 +28,10 @@
   - name: Set  version for 3.x
     set_fact:
       oc_version: "{{ cmdver.stdout | regex_search('openshift v[0-9]\\.[0-9]+') | replace('openshift v', '')  }}"
+
+  - name: Set 3.x default registry
+    set_fact:
+      default_registry: "docker-registry.default.svc:5000"
 
   - debug: msg={{ oc_version }}
 

--- a/roles/ocp-25021-cronjob/tasks/deploy.yml
+++ b/roles/ocp-25021-cronjob/tasks/deploy.yml
@@ -29,6 +29,6 @@
     definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
   vars:
     app_name: "{{ int_app_name }}"
-    docker_image: "docker-registry.default.svc:5000/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
+    docker_image: "{{ default_registry }}/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
 
 

--- a/roles/ocp-25090-jobs/tasks/deploy.yml
+++ b/roles/ocp-25090-jobs/tasks/deploy.yml
@@ -38,7 +38,7 @@
   vars:
     app_name: "{{ int_app_name }}"
     sleep_time: 1d
-    docker_image: "docker-registry.default.svc:5000/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
+    docker_image: "{{ default_registry }}/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
 
 
 - name: Deploy fast job using external image. This fob will end and should not be migrated

--- a/roles/ocp-25212-initcont/tasks/deploy.yml
+++ b/roles/ocp-25212-initcont/tasks/deploy.yml
@@ -30,5 +30,5 @@
   vars:
     replicas: 1
     app_name: "{{ int_app_name }}"
-    init_image: "docker-registry.default.svc:5000/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
+    init_image: "{{ default_registry }}/{{ namespace }}/{{ internal_image_name }}:{{ internal_image_tag }}"
 


### PR DESCRIPTION
Default registry has different names in 4.x and 3.x clusters. This PR selects the right default registry depending on the oc version, so that testcases can be migrated from 4.x to 4.x too.