### PR TITLE
Backwardcompatible cephclass

### DIFF
--- a/common_tasks/validate-defaults.yml
+++ b/common_tasks/validate-defaults.yml
@@ -16,14 +16,14 @@
   set_fact:
     csi_cephfs: "{{ item.metadata.name }}"
     csi_cephfs_installed: True
-  when: item.provisioner == 'openshift-storage.cephfs.csi.ceph.com'
+  when: item.provisioner is match( '.*cephfs.csi.ceph.com')
   loop: "{{ storage_classes.resources }}"
 
 - name: Get ceph rbd class name
   set_fact:
     csi_rbd: "{{ item.metadata.name }}"
     csi_rbd_installed: True
-  when: item.provisioner == 'openshift-storage.rbd.csi.ceph.com'
+  when: item.provisioner is match( '.*rbd.csi.ceph.com')
   loop: "{{ storage_classes.resources }}"
 
 - name: Is ceph installed


### PR DESCRIPTION
The name of the ceph storage classes have changed since we now deploy ceph using OCS operator in CI.

Nevertheless we already have environments that do not use OCS operator to deploy ceph. This change make the tests work with both, ceph deployed via OCS operator and without using OCS operator.