### PR TITLE
ocp-26032-maxns: Add k8s wait on deploy

### DIFF
--- a/roles/ocp-26032-maxns/tasks/deploy.yml
+++ b/roles/ocp-26032-maxns/tasks/deploy.yml
@@ -25,6 +25,7 @@
     state : present
     namespace : "{{ item.item }}"
     definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+    wait: yes
   vars:
     namespace: "{{ item.item }}"
     replicas: "{{ default_replicas }}"


### PR DESCRIPTION
Attempting to stabilize OCP3 API service fail/rejections during deployment