### PR TITLE
Add ocp-32075-retry testcase

### DIFF
--- a/roles/ocp-32075-retry/defaults/main.yml
+++ b/roles/ocp-32075-retry/defaults/main.yml
@@ -1,0 +1,14 @@
+namespace: "ocp-32075-retry"
+
+num_visits: 5
+
+migration_sample_name: "ocp-32075-retry"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: false

--- a/roles/ocp-32075-retry/tasks/deploy.yml
+++ b/roles/ocp-32075-retry/tasks/deploy.yml
@@ -1,0 +1,12 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Create openshift cake-php application from openshift templates
+  shell: "{{ oc_binary }} -n {{ namespace }} new-app --template django-psql-persistent"

--- a/roles/ocp-32075-retry/tasks/disable_internal_registry.yml
+++ b/roles/ocp-32075-retry/tasks/disable_internal_registry.yml
@@ -1,0 +1,11 @@
+- name: Disable internal registry. 3x cluster.
+  shell:  oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator
+  register: disable3_command
+  until: disable3_command.rc == 0
+  when: oc_version is version('4.1', '<')
+
+- name: Disable internal registry. 4x cluster.
+  shell:  "oc patch configs.imageregistry.operator.openshift.io cluster -p '{\"spec\":{\"managementState\": \"Removed\"} }' --type='merge'"
+  register: disable3_command
+  until: disable3_command.rc == 0
+  when: not oc_version is version('4.1', '<')

--- a/roles/ocp-32075-retry/tasks/enable_internal_registry.yml
+++ b/roles/ocp-32075-retry/tasks/enable_internal_registry.yml
@@ -1,0 +1,11 @@
+- name: Enable internal registry. 3x cluster.
+  shell:  oc scale --replicas 1 -n openshift-cluster-version deployments/cluster-version-operator
+  register: disable3_command
+  until: disable3_command.rc == 0
+  when: oc_version is version('4.1', '<')
+
+- name: Enable internal registry. 4x cluster.
+  shell:  "oc patch configs.imageregistry.operator.openshift.io cluster -p '{\"spec\":{\"managementState\": \"Managed\"} }' --type='merge'"
+  register: disable3_command
+  until: disable3_command.rc == 0
+  when: not oc_version is version('4.1', '<')

--- a/roles/ocp-32075-retry/tasks/main.yml
+++ b/roles/ocp-32075-retry/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: Get oc version
+  include_role:
+    name: migration_getfacts
+
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate-source.yml
+  when: (with_validate|bool) and (with_deploy|bool)
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)

--- a/roles/ocp-32075-retry/tasks/migrate.yml
+++ b/roles/ocp-32075-retry/tasks/migrate.yml
@@ -1,0 +1,33 @@
+- name: Migrate forcing a failue
+  block:
+  - name: Disable internal registry to create a connection problem
+    import_tasks: disable_internal_registry.yml
+
+  - name: Get velero last log line
+    shell: "oc -n openshift-migration logs $(oc get pods -n openshift-migration -l component=velero -o name)| tail -1"
+    register: velero_last_log
+    until: velero_last_log.rc == 0
+
+  - name: Execute migration
+    include_role:
+      name: migration_run
+
+  - name: Wait until velero reports a connection problem and retries once at least
+    shell: "oc -n openshift-migration logs $(oc get pods -n openshift-migration -l component=velero -o name) | tail -100"
+    register: velero_log
+    retries: 45
+    delay: 10
+    until: >
+          velero_log.rc == 0 and
+          (
+            velero_log.stdout|replace('\n', '') is  search( velero_last_log.stdout_lines[-1] + '.*copying image.*' + namespace+ '.*#0 failed, waiting.*#1 failed, waiting.*#2 failed, waiting') or
+            (
+              not velero_log.stdout|replace('\n', '') is search( velero_last_log.stdout_lines[-1]) and
+              velero_log.stdout|replace('\n', '') is search( 'copying image.*' + namespace+ '.*#0 failed, waiting [0-9+]s and then retrying')
+            )
+          )
+
+  always:
+  - name: Enable internal registry to fix the connection problem
+    import_tasks: enable_internal_registry.yml
+  when: with_migrate|bool

--- a/roles/ocp-32075-retry/tasks/track.yml
+++ b/roles/ocp-32075-retry/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-32075-retry/tasks/validate-source.yml
+++ b/roles/ocp-32075-retry/tasks/validate-source.yml
@@ -1,0 +1,55 @@
+- name: Check postgresql pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "name=postgresql"
+    field_selectors: 
+    - status.phase=Running
+  register: psqlpod
+  until: "true in (psqlpod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 30
+
+- name: Check application pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "name=django-psql-persistent"
+    field_selectors: 
+    - status.phase=Running
+  register: apppod
+  until: "true in (apppod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 30
+
+- name: Get route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "app=django-psql-persistent"
+  register: app_route
+  until: app_route.resources | length > 0
+  retries: 30
+
+- name: Acces the html file
+  uri:
+    url: http://{{ app_route.resources[0].spec.host }}
+    method: GET
+    status_code: 200
+    return_content: true
+  register: page_content
+  until: page_content.status == 200
+  with_sequence: "1-{{ num_visits }}"
+
+# /health uri will return the number of visits that the database has stored
+- name: Get num visits up to now
+  uri:
+    url: http://{{ app_route.resources[0].spec.host }}/health
+    method: GET
+    status_code: 200
+    return_content: true
+  register:  django_num_visits
+  until: django_num_visits.status == 200
+
+- name: Check num visits
+  fail:
+    msg: "Num visits has not the expected value. It should be {{ num_visits }} and the value retreived was {{ django_num_visits.content }}"
+  when: django_num_visits.content|int != num_visits|int

--- a/roles/ocp-32075-retry/tasks/validate-target.yml
+++ b/roles/ocp-32075-retry/tasks/validate-target.yml
@@ -1,0 +1,53 @@
+- name: Check mysql pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "name=postgresql"
+    field_selectors: 
+    - status.phase=Running
+  register: psqlpod
+  until: "true in (psqlpod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 30
+
+- name: Check application pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "name=django-psql-persistent"
+    field_selectors: 
+    - status.phase=Running
+  register: apppod
+  until: "true in (apppod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 30
+
+- name: Get route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "app=django-psql-persistent"
+  register: app_route
+  until: app_route.resources | length > 0
+  retries: 30
+
+- name: Acces the html file
+  uri:
+    url: http://{{ app_route.resources[0].spec.host }}
+    method: GET
+    status_code: 200
+    return_content: true
+  register: page_content
+
+# /health uri will return the number of visits that the database has stored
+- name: Get num visits up to now
+  uri:
+    url: http://{{ app_route.resources[0].spec.host }}/health
+    method: GET
+    status_code: 200
+    return_content: true
+  register:  django_num_visits
+  until: django_num_visits.status == 200
+
+- name: Check num visits
+  fail:
+    msg: "Num visits has not the expected value. It should be {{ num_visits + 1 }} and the value retreived was {{ fact_cake_num_visits }}"
+  when: django_num_visits.content|int != (num_visits|int + 1)


### PR DESCRIPTION
Add  a role to run ocp-32075-retry  testcase

1. Deploy a django application building an image and an imagestream
2. Feed data into the application
3. Disable target cluster's internal registry to create a network problem
4. Execute migration
5. Wait until velero reports the problem and start retrying
6. Enable target cluster's internal registry to fix the network problem
7. Check that velero can recover from the problem, the migration ends OK and the application is correctly migrated
